### PR TITLE
feat: add instructions for setting up terminal theme and font

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ You can use the `ENABLE` parameter to install them.
 
 Restart the terminal to configure Powerlevel10k.
 
-The script will download the fonts required for the Powerlevel10k theme.
+The script will download the fonts required for the Powerlevel10k theme. You will need to set them up in your terminal manually.
 
-You will need to set them up in your terminal manually.
+1. Set the "Terminal Theme" to `Pro`.
+2. Configure the font for the "Terminal Pro Theme" as `MesloLGS NF` with a font size of `13`.
+3. Set the "Terminal Pro Theme" shell to `close when the shell exits completely`.
 
 ## 4. TODO
 

--- a/vscode_plugin/README.md
+++ b/vscode_plugin/README.md
@@ -24,6 +24,9 @@
 |               [Ligatures Limited](https://marketplace.visualstudio.com/items?itemName=kshetline.ligatures-limited)                |
 |            [Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense)            |
 |                      [Todo Tree](https://marketplace.visualstudio.com/items?itemName=Gruntfuggly.todo-tree)                       |
+|                      [Error Lens](https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens)                       |
+|               [Material Icon Theme](https://marketplace.visualstudio.com/items?itemName=PKief.material-icon-theme)                |
+|                  [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme)                  |
 
 ## 2. Git/Github
 

--- a/vscode_plugin/settings.json
+++ b/vscode_plugin/settings.json
@@ -1,0 +1,51 @@
+{
+    "git.enableSmartCommit": true,
+    "git.autofetch": true,
+    "terminal.integrated.fontFamily": "MesloLGS NF",
+    "git.confirmSync": false,
+    "editor.formatOnSave": true,
+    "[markdown]": {
+        "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
+    },
+    "markdown.extension.toc.levels": "2..6",
+    "[shellscript]": {
+        "editor.defaultFormatter": "foxundermoon.shell-format"
+    },
+    "editor.fontFamily": "Fira Code",
+    "editor.fontLigatures": true,
+    "better-comments.tags": [
+        {
+            "tag": "!",
+            "color": "#FF2D00",
+            "strikethrough": false,
+            "underline": false,
+            "backgroundColor": "transparent",
+            "bold": false,
+            "italic": false
+        },
+        {
+            "tag": "?",
+            "color": "#3498DB",
+            "strikethrough": false,
+            "underline": false,
+            "backgroundColor": "transparent",
+            "bold": false,
+            "italic": false
+        },
+        {
+            "tag": "*",
+            "color": "#98C379",
+            "strikethrough": false,
+            "underline": false,
+            "backgroundColor": "transparent",
+            "bold": false,
+            "italic": false
+        }
+    ],
+    "todo-tree.highlights.useColourScheme": true,
+    "cSpell.diagnosticLevel": "Hint",
+    "workbench.tree.indent": 22,
+    "workbench.iconTheme": "material-icon-theme",
+    "workbench.colorTheme": "One Dark Pro",
+    "oneDarkPro.bold": true
+}


### PR DESCRIPTION
Added instructions in the README.md file on how to set up the "Terminal Theme" to `Pro` and configure the font for the "Terminal Pro Theme" as `MesloLGS NF` with a font size of `13`. Also added instructions to set the "Terminal Pro Theme" shell to `close when the shell exits completely`.

Refactored the vscode_plugin/README.md file to include new recommended extensions: [Error Lens](https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens), [Material Icon Theme](https://marketplace.visualstudio.com/items?itemName=PKief.material-icon-theme), and [One Dark Pro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme).

Created vscode_plugin/settings.json file with various settings for Git, Markdown, Shell Script, and other extensions.