### PR TITLE
docs: 校正并精简 CLAUDE.md，统一 macos/main.sh 的 export 约定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,19 +13,16 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
 ```
 
 `main.sh` shallow-clones the repo (branch from `--branch`, default `master`) into a
-temp dir and hands off to `<setup>/main.sh`, forwarding all unrecognized flags. So
-the top-level `main.sh` only understands `--branch` and `--setup`; every other flag is
-parsed by a downstream script.
+temp dir and hands off to `<setup>/main.sh` (default `macos`), forwarding all unrecognized
+flags — the top-level `main.sh` itself understands only `--branch` and `--setup`.
 
 ## Linting / running
 
 - Lint: `shellcheck **/*.sh` (config in `.shellcheckrc`; `SC2016` disabled because
   single-quoted `jq`/`sed` programs contain `$` that is not a shell expansion).
-- No test suite. To exercise a change without a full remote install, run a setup
-  script directly, e.g. `bash debian/main.sh --app-tmux` — each script `cd`s to its own
-  dir on run, so relative `bash "./app/..."` calls resolve correctly.
-- Requires Bash 4+ (`mapfile`, `${VAR%.*}`, `(( ))`). macOS's system Bash 3.2 will not
-  run the `container` Dockerfile logic, but the target platforms ship Bash 4+.
+- No test suite. To exercise a change without the full remote install, run a dispatcher
+  directly, e.g. `bash debian/main.sh --app-tmux` — note it still does real `apt` installs
+  and always runs `command/zsh.sh` + `command/omz.sh` first.
 
 ## Architecture
 
@@ -37,18 +34,19 @@ Three independent setup trees, selected by `--setup`:
 - `container/` — builds and runs a Docker dev container (`dev-container`) or the
   `copilot-api` image.
 
-### The dispatcher pattern (every `main.sh` and leaf script follows it)
+### The dispatcher pattern
 
-1. Env-var defaults with override: `export FOO="${FOO:-0}"`. `debian/main.sh` uses
-   `export` so the flags propagate as env vars into child scripts; leaf scripts read the
-   same vars back (e.g. `tmux.sh` and `claude/main.sh` both read `AGENT_CLAUDE`).
+1. Env-var defaults with override: `export FOO="${FOO:-0}"`. The platform roots `debian/main.sh`
+   and `macos/main.sh` export their flag vars so leaf scripts can read them.
 2. `parse_args()` walks `$@`, sets vars for known flags, and pushes everything else onto
    `POSITIONAL` so downstream scripts can still see their own flags.
 3. Boolean flags (`--app-tmux`) `shift` once; value flags (`--branch <v>`) use the
    `numOfArgs` idiom that guards against a missing trailing value before `shift`ing twice.
-4. `main()` runs, gated on the `FOO == "1"` vars. A component's flag is checked in TWO
-   places: the parent `main.sh` decides whether to invoke the leaf script, and the leaf
-   script re-reads the env var for sub-behavior.
+4. `main()` runs each enabled component's leaf script, gated on `FOO == "1"`. Exporting is a
+   deliberate cross-cutting mechanism: a leaf can read *another* component's flag to add
+   integration config only when both are enabled — e.g. `tmux.sh` reads `AGENT_CLAUDE` (adds
+   Claude Code passthrough / extended-keys when `--app-tmux` + `--agent-claude`); `micro.sh`
+   reads `APP_VSCODE`. Those env reads are intentional — not a missing `parse_args` to add.
 5. Standard footer guard so scripts are both runnable and sourceable:
    ```bash
    if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
@@ -81,7 +79,7 @@ install non-interactively and switches the login shell.
 ### copilot-api integration
 
 `copilot_api/main.sh` queries a running copilot-api server (`/v1/models`), picks the newest
-opus/sonnet/haiku model ids (preferring the `[1m]` variants via `sort -V | tail -n1`), and
+opus/sonnet/haiku model ids (preferring `[1m]` variants, newest picked by `sort -V`), and
 renders `~/.claude/settings.json` from the `settings.json` template using `jq`, then installs
 the Claude plugin marketplace/plugin. It expects the copilot-api server to already be reachable
 at `AGENT_CLAUDE_ANTHROPIC_BASE_URL` (default `http://localhost:4141`).

--- a/macos/main.sh
+++ b/macos/main.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-APP_VSCODE="${APP_VSCODE:-0}"
-APP_SSH="${APP_SSH:-0}"
+export APP_VSCODE="${APP_VSCODE:-0}"
+export APP_SSH="${APP_SSH:-0}"
 
 parse_args() {
     POSITIONAL=()


### PR DESCRIPTION
## 背景

对 `CLAUDE.md` 做了一次全面审查——逐条核对全部脚本、`Dockerfile`、`README.md`、`.shellcheckrc`——修正与代码现状不符的表述、精简冗余，减少对 AI 的干扰；并统一 `macos/main.sh` 与 `debian/main.sh` 的 `export` 约定。

## 改动

**CLAUDE.md 纠错**
- 删除错误的 “Requires Bash 4+”（`mapfile` 只在 `Dockerfile` 内、由容器 bash 执行；`${VAR%.*}`/`(( ))` 本就是 Bash 3 特性）
- dispatcher 小节标题不再声称 “every main.sh and leaf script follows it”（17 个叶子脚本实际仅 3 个有 `parse_args`）
- 要点 4 “checked in TWO places” 改写为准确的跨切面描述（叶子读的是*另一个*组件的 flag）
- 修正 copilot-api `[1m]` 选择的归因（偏好来自 `grep`，`sort -V` 仅取最新）

**CLAUDE.md 精简**
- 合并 Overview 同义复述，补上 `--setup` 默认值 `macos`
- 删除偏长的 Entry points 一节，将其唯一关键的“export 跨切面设计”准确并入 dispatcher 要点 4
- 去除 Linting 中与 footer 重复的说明

**代码**
- `macos/main.sh` 的 `APP_VSCODE`/`APP_SSH` 改为 `export`，与 `debian/main.sh` 一致，使跨切面配置能力在 macos 上同样可用。行为中性：macos 树内无叶子脚本读取这两个裸变量（已 `grep` 核实）。

## 验证
- `bash -n macos/main.sh` 通过；`shellcheck macos/main.sh` 无告警
- `grep` 复核：`.sh` 中无 `mapfile`；有 `parse_args` 的叶子脚本确为 `git.sh` / `command/omz.sh` / `macos ssh.sh`；现仅 debian + macos 两个根 `export`
- 通读 `CLAUDE.md`：无悬空引用、无删节断裂

🤖 Generated with [Claude Code](https://claude.com/claude-code)
