### PR TITLE
feat: 添加 --app-github 组件，安装 GitHub CLI (gh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
 | `--app-docker`      |                                           |
 | `--app-git`         | `--app-git-user-name <v>`                 |
 |                     | `--app-git-user-email <v>`                |
+| `--app-github`      |                                           |
 | `--app-micro`       |                                           |
 | `--app-tmux`        |                                           |
 | `--app-vscode`      |                                           |

--- a/debian/app/github.sh
+++ b/debian/app/github.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() {
+    (type -p wget > /dev/null || (sudo apt update && sudo apt install wget -y)) \
+        && sudo mkdir -p -m 755 /etc/apt/keyrings \
+        && out=$(mktemp) && wget -nv "-O$out" https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        && sudo cp "$out" /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+        && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+        && sudo mkdir -p -m 755 /etc/apt/sources.list.d \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+        && sudo apt update \
+        && sudo apt install gh -y
+
+    sed -i '/^plugins=(/s/)/ gh)/' "$HOME/.zshrc"
+}
+
+if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    main "$@"
+fi

--- a/debian/main.sh
+++ b/debian/main.sh
@@ -6,6 +6,7 @@ export AGENT_CLAUDE="${AGENT_CLAUDE:-0}"
 
 export APP_DOCKER="${APP_DOCKER:-0}"
 export APP_GIT="${APP_GIT:-0}"
+export APP_GITHUB="${APP_GITHUB:-0}"
 export APP_MICRO="${APP_MICRO:-0}"
 export APP_TMUX="${APP_TMUX:-0}"
 export APP_VSCODE="${APP_VSCODE:-0}"
@@ -34,6 +35,10 @@ parse_args() {
                 ;;
             --app-git)
                 APP_GIT=1
+                shift
+                ;;
+            --app-github)
+                APP_GITHUB=1
                 shift
                 ;;
             --app-micro)
@@ -102,6 +107,10 @@ main() {
 
     if [[ $APP_GIT == "1" ]]; then
         bash "./app/git.sh" "$@"
+    fi
+
+    if [[ $APP_GITHUB == "1" ]]; then
+        bash "./app/github.sh" "$@"
     fi
 
     if [[ $APP_MICRO == "1" ]]; then


### PR DESCRIPTION
## 变更

为 debian setup 树新增可选组件 `--app-github`，通过 GitHub 官方 apt 仓库安装 GitHub CLI (`gh`)。

- `debian/main.sh`：按字母序新增 `APP_GITHUB` 默认值、`--app-github` 布尔 flag、`main()` gated call
- `debian/app/github.sh`：新 leaf 脚本（`wget` 下载官方 keyring → `sudo cp` 到 `/etc/apt/keyrings/` → 添加 apt 源 → `apt install gh`），并按约定追加 oh-my-zsh `gh` 插件
- `README.md`：debian flag 表格新增 `--app-github` 行

`shellcheck` 与 `bash -n` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)