### PR TITLE
feat: 为 dev-container 注入 COLORTERM=truecolor，启用容器内真彩色

### DIFF
--- a/container/dev-container/Dockerfile
+++ b/container/dev-container/Dockerfile
@@ -5,11 +5,13 @@ ARG encoding
 ARG language
 ARG tz
 ARG term=xterm-256color
+ARG colorterm=truecolor
 
 ENV LANG=${lang}.${encoding}
 ENV LANGUAGE=${language}
 ENV TZ=${tz}
 ENV TERM=${term}
+ENV COLORTERM=${colorterm}
 
 SHELL ["/usr/bin/bash", "-c"]
 


### PR DESCRIPTION
## 背景
终端链路为 `Mac 终端 → SSH → Debian → tmux → docker exec → container`。`COLORTERM` 在 Mac 上存在（`truecolor`），但 SSH 默认只随 pty 透传 `TERM`，`COLORTERM` 在 SSH 这一跳就丢失，导致 Debian、tmux、容器内全为空，容器内程序因此无法识别 24 位真彩色，颜色显示异常。

## 改动
`container/dev-container/Dockerfile`：比照既有 `TERM` 的写法，新增带默认值的 `ARG colorterm=truecolor` 与 `ENV COLORTERM=${colorterm}`，把真彩色能力烧进镜像。不从宿主传入，因为宿主 Debian 的 `COLORTERM` 本身就是空的（同 `term`，也未由 `main.sh` 以 build-arg 传入）。

## 验证
- 重建后 `docker exec -it <container> bash -lc 'echo $COLORTERM'` → 期望 `truecolor`
- 容器内 `printf '\e[38;2;255;100;0mTRUECOLOR\e[0m\n'` 显示为橙色

## 备注
端到端真彩色还依赖中间 tmux 的 RGB 直通（Debian `~/.tmux.conf` 加 `set -as terminal-features ",xterm-256color:RGB"`），属宿主链路，与本次改动独立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)