### PR TITLE
feat: 添加 --command-utils 打包安装命令行工具,迁入 git 配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
 |                     | `--agent-claude-anthropic-base-url <v>`   |
 |                     | `--agent-claude-anthropic-auth-token <v>` |
 | `--app-docker`      |                                           |
-| `--app-git`         | `--app-git-user-name <v>`                 |
-|                     | `--app-git-user-email <v>`                |
 | `--app-github`      |                                           |
 | `--app-micro`       |                                           |
 | `--app-tmux`        |                                           |
@@ -49,6 +47,8 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
 | `--code-powershell` |                                           |
 | `--code-python`     |                                           |
 | `--code-rust`       |                                           |
+| `--command-utils`   | `--command-utils-git-user-name <v>`       |
+|                     | `--command-utils-git-user-email <v>`      |
 | `--tools-node`      |                                           |
 | `--tools-protobuf`  |                                           |
 

--- a/debian/command/utils.sh
+++ b/debian/command/utils.sh
@@ -2,28 +2,28 @@
 
 set -euo pipefail
 
-APP_GIT_USER_NAME="${APP_GIT_USER_NAME:-}"
-APP_GIT_USER_EMAIL="${APP_GIT_USER_EMAIL:-}"
+COMMAND_UTILS_GIT_USER_NAME="${COMMAND_UTILS_GIT_USER_NAME:-}"
+COMMAND_UTILS_GIT_USER_EMAIL="${COMMAND_UTILS_GIT_USER_EMAIL:-}"
 
 parse_args() {
     POSITIONAL=()
     while (($# > 0)); do
         case "$1" in
-            --app-git-user-name)
+            --command-utils-git-user-name)
                 numOfArgs=1 # number of switch arguments
                 if (($# < numOfArgs + 1)); then
                     shift $#
                 else
-                    APP_GIT_USER_NAME="$2"
+                    COMMAND_UTILS_GIT_USER_NAME="$2"
                     shift $((numOfArgs + 1)) # shift 'numOfArgs + 1' to bypass switch and its value
                 fi
                 ;;
-            --app-git-user-email)
+            --command-utils-git-user-email)
                 numOfArgs=1 # number of switch arguments
                 if (($# < numOfArgs + 1)); then
                     shift $#
                 else
-                    APP_GIT_USER_EMAIL="$2"
+                    COMMAND_UTILS_GIT_USER_EMAIL="$2"
                     shift $((numOfArgs + 1)) # shift 'numOfArgs + 1' to bypass switch and its value
                 fi
                 ;;
@@ -35,11 +35,26 @@ parse_args() {
     done
 }
 
-main() {
-    git config --global user.name "$APP_GIT_USER_NAME"
-    git config --global user.email "$APP_GIT_USER_EMAIL"
+setup_git() {
+    if [[ -n $COMMAND_UTILS_GIT_USER_NAME ]]; then
+        git config --global user.name "$COMMAND_UTILS_GIT_USER_NAME"
+    fi
+    if [[ -n $COMMAND_UTILS_GIT_USER_EMAIL ]]; then
+        git config --global user.email "$COMMAND_UTILS_GIT_USER_EMAIL"
+    fi
 
     sed -i '/^plugins=(/s/)/ git)/' "$HOME/.zshrc"
+}
+
+main() {
+    sudo apt-get update
+    sudo apt-get install -y \
+        tree \
+        jq \
+        unzip \
+        glow
+
+    setup_git
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then

--- a/debian/main.sh
+++ b/debian/main.sh
@@ -2,10 +2,11 @@
 
 set -euo pipefail
 
+export COMMAND_UTILS="${COMMAND_UTILS:-0}"
+
 export AGENT_CLAUDE="${AGENT_CLAUDE:-0}"
 
 export APP_DOCKER="${APP_DOCKER:-0}"
-export APP_GIT="${APP_GIT:-0}"
 export APP_GITHUB="${APP_GITHUB:-0}"
 export APP_MICRO="${APP_MICRO:-0}"
 export APP_TMUX="${APP_TMUX:-0}"
@@ -25,6 +26,10 @@ parse_args() {
     POSITIONAL=()
     while (($# > 0)); do
         case "$1" in
+            --command-utils)
+                COMMAND_UTILS=1
+                shift
+                ;;
             --agent-claude)
                 AGENT_CLAUDE=1
                 shift
@@ -32,10 +37,6 @@ parse_args() {
             --app-docker)
                 APP_DOCKER=1
                 shift # shift once since flags have no values
-                ;;
-            --app-git)
-                APP_GIT=1
-                shift
                 ;;
             --app-github)
                 APP_GITHUB=1
@@ -97,16 +98,16 @@ main() {
     bash "./command/zsh.sh" "$@"
     bash "./command/omz.sh" "$@"
 
+    if [[ $COMMAND_UTILS == "1" ]]; then
+        bash "./command/utils.sh" "$@"
+    fi
+
     if [[ $AGENT_CLAUDE == "1" ]]; then
         bash "./agent/claude/main.sh" "$@"
     fi
 
     if [[ $APP_DOCKER == "1" ]]; then
         bash "./app/docker.sh" "$@"
-    fi
-
-    if [[ $APP_GIT == "1" ]]; then
-        bash "./app/git.sh" "$@"
     fi
 
     if [[ $APP_GITHUB == "1" ]]; then


### PR DESCRIPTION
## 概述

新增 `--command-utils` 组件:打包安装常用命令行工具,并把原 `--app-git` 的逻辑迁移进来。

## 改动

- 新增 `debian/command/utils.sh`:一条 `apt-get install -y` 装 `tree jq unzip glow`;git 逻辑独立为 `setup_git()`(git 身份配置 + oh-my-zsh git 插件)。
- `--command-utils` 在 dispatcher 里排在无条件的 `zsh`/`omz` 之后、其余 gated 组件之前**最先执行**。
- git 身份配置加了**空值守卫**(未传值不执行 `git config`,避免清空已有身份);值参数改名为 `--command-utils-git-user-name` / `--command-utils-git-user-email`。
- 移除 `--app-git`,原 `debian/app/git.sh` 迁移为 `debian/command/utils.sh`。
- README flag 表同步更新。

## 验证

- `shellcheck debian/command/utils.sh debian/main.sh` 干净。
- parse_args 值参数解析冒烟通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)