### PR TITLE
feat: micro 迁入 app/micro/ 子目录并完善配置

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Three independent setup trees, selected by `--setup`:
 4. `main()` runs each enabled component's leaf script, gated on `FOO == "1"`. Exporting is a
    deliberate cross-cutting mechanism: a leaf can read *another* component's flag to add
    integration config only when both are enabled — e.g. `tmux.sh` reads `AGENT_CLAUDE` (adds
-   Claude Code passthrough / extended-keys when `--app-tmux` + `--agent-claude`); `micro.sh`
+   Claude Code passthrough / extended-keys when `--app-tmux` + `--agent-claude`); `micro/main.sh`
    reads `APP_VSCODE`. Those env reads are intentional — not a missing `parse_args` to add.
 5. Standard footer guard so scripts are both runnable and sourceable:
    ```bash

--- a/debian/app/micro/main.sh
+++ b/debian/app/micro/main.sh
@@ -9,6 +9,10 @@ main() {
     sudo apt-get install -y micro
 
     micro -plugin install detectindent
+    micro -plugin install filemanager
+
+    mkdir -p "$HOME/.config/micro"
+    cp ./settings.json "$HOME/.config/micro/settings.json"
 
     {
         echo ''
@@ -20,7 +24,9 @@ main() {
             echo 'fi'
         fi
         echo 'export VISUAL="$EDITOR"'
-
+        echo ''
+        echo '# Micro'
+        echo "alias micror='micro -readonly true'"
     } >> "$HOME/.zshrc"
 }
 

--- a/debian/app/micro/settings.json
+++ b/debian/app/micro/settings.json
@@ -1,0 +1,15 @@
+{
+  "colorscheme": "one-dark",
+  "diffgutter": true,
+  "hlsearch": true,
+  "hltrailingws": true,
+  "matchbracestyle": "highlight",
+  "mkparents": true,
+  "parsecursor": true,
+  "rmtrailingws": true,
+  "savecursor": true,
+  "saveundo": true,
+  "scrollbar": true,
+  "showchars": "tab=»,itab=»",
+  "truecolor": true
+}

--- a/debian/main.sh
+++ b/debian/main.sh
@@ -115,7 +115,7 @@ main() {
     fi
 
     if [[ $APP_MICRO == "1" ]]; then
-        bash "./app/micro.sh" "$@"
+        bash "./app/micro/main.sh" "$@"
     fi
 
     if [[ $APP_TMUX == "1" ]]; then


### PR DESCRIPTION
## 概述
将 micro 编辑器安装脚本迁入 `debian/app/micro/` 子目录，并完善其 settings 与插件。

## 改动
- 迁移 `debian/app/micro.sh` → `debian/app/micro/main.sh`（保留 git 历史）
- 新增 `debian/app/micro/settings.json`：one-dark 主题、`truecolor`，及 `diffgutter`/`hlsearch`/`hltrailingws`/`parsecursor`/`savecursor`/`saveundo`/`scrollbar`、`matchbracestyle=highlight`、`mkparents`、`rmtrailingws`、`showchars`
- `main.sh` 安装 `detectindent` + `filemanager` 插件；`.zshrc` 增加 `# Micro` 块（`alias micror` 只读打开）
- 更新 `debian/main.sh` 调用路径与 `CLAUDE.md`

## 说明
- 用 `cp` 落地 settings（静态内容，无需 jq），对齐 `copilot_api` 的「子目录 + main.sh + 模板」模式
- `showchars` 为 micro ≥2.0.15 选项；Debian trixie 当前打包 2.0.14，会被静默忽略、升级后自动生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)
