### PR TITLE
feat: 添加 .gitignore 采用官方 Agents 配置并启用 Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,68 @@
+# AI agents and assistants
+#
+# Some common agent instruction and project configuration files are listed
+# below as commented-out examples. They are often intentionally committed and
+# shared with a team, so only uncomment them if they are local-only in your
+# project.
+
+# GEMINI.md
+# WARP.md
+# CRUSH.md
+# QWEN.md
+
+# OpenAI Codex
+# AGENTS.md
+# .codex/
+
+# Aider
+.aider.input.history
+.aider.chat.history.md
+.aider.llm.history
+.aider.tags.cache.v*
+# .aiderignore
+
+# Claude Code
+.claude/*.local.json
+.claude/**/*.log
+CLAUDE.local.md
+.claude/
+
+# Gemini CLI
+gemini-debug.log
+.gemini-clipboard/
+# .gemini/
+
+# Cursor AI
+# .cursorrules
+# .cursor/
+# .cursor.json
+# .cursor-settings.yaml
+
+# Continue
+# .continue/
+# .continuerc.json
+
+# Cline
+# .cline/
+# .clinerules
+# cline.json
+
+# Other agent/editor project config
+# .warp/
+# .crush/
+# .codeium/
+# .deepseek/
+# .amazon-codewhisperer/
+# .tabnineignore
+# .tabnine/
+
+# GitHub Copilot
+# .github/copilot-instructions.md
+
+# Windsurf Editor
+# .windsurfrules
+# .windsurf/
+
+# Replit AI Development
+# .replit
+# replit.nix


### PR DESCRIPTION
## 变更

- 以 GitHub 官方 [`Global/Agents.gitignore`](https://raw.githubusercontent.com/github/gitignore/refs/heads/main/Global/Agents.gitignore) 逐字作为仓库 `.gitignore` 内容(68 行)。
- 启用 `# Claude Code` 段落:将 `# .claude/` 取消注释为 `.claude/`,从此忽略整个 `.claude/` 目录(含临时 worktree 检出)。

## 说明

- `.claude/` 此前从未被 git 跟踪,加入忽略即可,无需 `git rm --cached`。
- 启用整目录忽略后,同段的 `.claude/*.local.json`、`.claude/**/*.log` 成为冗余,但按上游原文保留、未删减。

🤖 Generated with [Claude Code](https://claude.com/claude-code)