### PR TITLE
feat: --command-utils 并入现代命令行工具

### DIFF
--- a/debian/app/micro/main.sh
+++ b/debian/app/micro/main.sh
@@ -24,9 +24,6 @@ main() {
             echo 'fi'
         fi
         echo 'export VISUAL="$EDITOR"'
-        echo ''
-        echo '# Micro'
-        echo "alias micror='micro -readonly true'"
     } >> "$HOME/.zshrc"
 }
 

--- a/debian/command/utils.sh
+++ b/debian/command/utils.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 COMMAND_UTILS_GIT_USER_NAME="${COMMAND_UTILS_GIT_USER_NAME:-}"
 COMMAND_UTILS_GIT_USER_EMAIL="${COMMAND_UTILS_GIT_USER_EMAIL:-}"
 
+APP_MICRO="${APP_MICRO:-0}"
+
 parse_args() {
     POSITIONAL=()
     while (($# > 0)); do
@@ -68,6 +70,10 @@ configure_zshrc() {
         # eza 取代 ls / tree（omz 的 ll/la/l 会经别名递归复用 ls）
         echo "alias ls='eza --group-directories-first'"
         echo "alias tree='eza --tree'"
+        # micro 只读别名（仅当同时启用 --app-micro）
+        if [[ $APP_MICRO == "1" ]]; then
+            echo "alias micror='micro -readonly true'"
+        fi
         # shell 集成
         echo 'eval "$(zoxide init zsh)"'
         echo 'eval "$(fzf --zsh)"'

--- a/debian/command/utils.sh
+++ b/debian/command/utils.sh
@@ -43,18 +43,60 @@ setup_git() {
         git config --global user.email "$COMMAND_UTILS_GIT_USER_EMAIL"
     fi
 
+    # git-delta 作为 diff 分页器
+    git config --global core.pager delta
+    git config --global interactive.diffFilter 'delta --color-only'
+    git config --global delta.navigate true
+    git config --global delta.line-numbers true
+    git config --global merge.conflictStyle zdiff3
+
     sed -i '/^plugins=(/s/)/ git)/' "$HOME/.zshrc"
+}
+
+configure_zshrc() {
+    # zoxide 取代 omz 的 z 插件；同新增一样用一行 sed 删除
+    # \< \> 词边界只删完整的 z，不误伤 zsh-* 等
+    sed -i '/^plugins=(/{ s/\<z\> \+//; s/ \+\<z\>//; }' "$HOME/.zshrc"
+
+    if [[ -s "$HOME/.zshrc" ]]; then echo >> "$HOME/.zshrc"; fi
+
+    {
+        echo '# Modern CLI tools'
+        # Debian 二进制改名坑：恢复习惯名
+        echo "alias bat='batcat'"
+        echo "alias fd='fdfind'"
+        # eza 取代 ls / tree（omz 的 ll/la/l 会经别名递归复用 ls）
+        echo "alias ls='eza --group-directories-first'"
+        echo "alias tree='eza --tree'"
+        # shell 集成
+        echo 'eval "$(zoxide init zsh)"'
+        echo 'eval "$(fzf --zsh)"'
+    } >> "$HOME/.zshrc"
 }
 
 main() {
     sudo apt-get update
     sudo apt-get install -y \
-        tree \
         jq \
         unzip \
-        glow
+        glow \
+        eza \
+        bat \
+        fd-find \
+        ripgrep \
+        zoxide \
+        fzf \
+        git-delta \
+        tealdeer \
+        hyperfine \
+        sd \
+        lazygit \
+        xh
+
+    tldr --update || true # 预热 tealdeer 离线缓存，网络失败不致命
 
     setup_git
+    configure_zshrc
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then


### PR DESCRIPTION
## 概述

为 `--command-utils` 并入一套 Debian 13 (trixie) 原生的现代命令行工具，替换/增强传统命令，提升开发终端体验。核心改动集中在 `debian/command/utils.sh`（并从 `app/micro` 迁入 micror 别名），dispatcher 与 README 无需改动。

## 改动

**现代工具（`debian/command/utils.sh`）**
- apt 安装 12 个开发向工具：`eza` `bat` `fd-find` `ripgrep` `zoxide` `fzf` `git-delta` `tealdeer` `hyperfine` `sd` `lazygit` `xh`；删除被 eza 替代的 `tree`。
- 别名（保守）：`ls`→eza（`ll`/`la` 复用 oh-my-zsh 递归）、`tree`→`eza --tree`、恢复 `bat`/`fd` 习惯名；不覆盖 `cat`/`find`/`grep`。
- shell 集成：`zoxide`、`fzf` 的 `eval` 初始化。
- `setup_git` 统管 git 配置，新增 git-delta 作为 diff 分页器。
- 清理冗余：删 oh-my-zsh 的 `z` 插件（zoxide 取代）。

**micror 迁移（`debian/app/micro/main.sh` → `utils.sh`）**
- 将 `micror='micro -readonly true'` 迁入 utils 现代工具集，按 `APP_MICRO` 门控——仅 `--command-utils` + `--app-micro` 同启时生效（cross-cutting，同 tmux 读 `AGENT_CLAUDE`）。

## 测试

- `shellcheck debian/command/utils.sh debian/app/micro/main.sh` 通过。
- 删 `z` 的 sed 实测（开头/中间/结尾、不误伤 `zsh-*`）。
- plugins 变换流程模拟正确。
- micror 门控隔离测试：`APP_MICRO=1` 写入、`=0` 不写入。
- 目标环境 `debian:trixie`，15 个 apt 包名与 `fzf --zsh` 均已核实。

🤖 Generated with [Claude Code](https://claude.com/claude-code)