### PR TITLE
feat: tmux 集成 sesh 会话管理器,按 --command-utils 门控

### DIFF
--- a/debian/app/tmux.sh
+++ b/debian/app/tmux.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 AGENT_CLAUDE="${AGENT_CLAUDE:-0}"
+COMMAND_UTILS="${COMMAND_UTILS:-0}"
 
 install_oh_my_tmux() {
     mkdir -p "$HOME/.config"
@@ -13,11 +14,24 @@ install_oh_my_tmux() {
     bash "$install_sh" < /dev/null
 }
 
+install_sesh() {
+    curl -fsSL "https://github.com/joshmedeski/sesh/releases/latest/download/sesh_Linux_x86_64.tar.gz" \
+        | sudo tar -xzf - -C /usr/local/bin sesh
+}
+
 configure_tmux() {
     local conf="$HOME/.config/tmux/tmux.conf.local"
 
     sed -i 's/^#set -g mouse on$/set -g mouse on/' "$conf"
-    sed -i 's/^#set -g history-limit .*/set -g history-limit 10000/' "$conf"
+    sed -i 's/^#set -g history-limit .*/set -g history-limit 50000/' "$conf"
+
+    if [[ $COMMAND_UTILS == "1" ]]; then
+        {
+            echo ''
+            echo 'set -g detach-on-destroy off'
+            echo 'bind-key T display-popup -w 80% -h 70% -E "sesh picker"'
+        } >> "$conf"
+    fi
 
     if [[ $AGENT_CLAUDE == "1" ]]; then
         {
@@ -35,6 +49,11 @@ main() {
     sudo apt-get install -y tmux
 
     install_oh_my_tmux
+
+    if [[ $COMMAND_UTILS == "1" ]]; then
+        install_sesh
+    fi
+
     configure_tmux
 
     sed -i '/^plugins=(/s/)/ tmux)/' "$HOME/.zshrc"


### PR DESCRIPTION
集成 sesh:install_sesh 下载二进制到 /usr/local/bin;prefix+T 弹 sesh picker;因硬依赖
  zoxide 按 COMMAND_UTILS 门控;history 50000。