### PR TITLE
feat: --command-utils 扩充现代 CLI 工具集并规范 omz 插件

### DIFF
--- a/debian/app/docker.sh
+++ b/debian/app/docker.sh
@@ -34,10 +34,17 @@ add_group() {
     sudo usermod -aG docker "$USER"
 }
 
+install_lazydocker() {
+    # 官方安装脚本；默认装入 $HOME/.local/bin（已在 PATH）
+    curl -fsSL "https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh" \
+        | bash
+}
+
 main() {
     add_repo
     install_docker
     add_group
+    install_lazydocker
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then

--- a/debian/command/omz.sh
+++ b/debian/command/omz.sh
@@ -65,7 +65,7 @@ install_plugin() {
         return 1
     fi
 
-    sed -i 's/^plugins=(.*)/plugins=(z sudo)/' "$HOME/.zshrc"
+    sed -i 's/^plugins=(.*)/plugins=(aliases dirhistory extract sudo z)/' "$HOME/.zshrc"
 
     # Ref. https://github.com/Pilaton/OhMyZsh-full-autoupdate?tab=readme-ov-file#installing
     git clone "https://github.com/Pilaton/OhMyZsh-full-autoupdate.git" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/ohmyzsh-full-autoupdate"

--- a/debian/command/utils.sh
+++ b/debian/command/utils.sh
@@ -60,6 +60,11 @@ configure_zshrc() {
     # \< \> 词边界只删完整的 z，不误伤 zsh-* 等
     sed -i '/^plugins=(/{ s/\<z\> \+//; s/ \+\<z\>//; }' "$HOME/.zshrc"
 
+    # fzf-tab：用 fzf 界面接管 Tab 补全。必须早于 zsh-autosuggestions /
+    # zsh-syntax-highlighting 加载，故「头插」到 plugins 开头（对称于尾插 s/)/ x)/）
+    git clone "https://github.com/Aloxaf/fzf-tab" "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/fzf-tab"
+    sed -i '/^plugins=(/s/(/(fzf-tab /' "$HOME/.zshrc"
+
     if [[ -s "$HOME/.zshrc" ]]; then echo >> "$HOME/.zshrc"; fi
 
     {
@@ -77,7 +82,33 @@ configure_zshrc() {
         # shell 集成
         echo 'eval "$(zoxide init zsh)"'
         echo 'eval "$(fzf --zsh)"'
+        # yazi 官方 shell wrapper：以 y 启动，退出时 cd 到浏览的目录
+        echo 'function y() {'
+        echo '    local tmp="$(mktemp -t "yazi-cwd.XXXXXX")" cwd'
+        echo '    command yazi "$@" --cwd-file="$tmp"'
+        echo '    IFS= read -r -d '\'''\'' cwd < "$tmp"'
+        echo '    [ "$cwd" != "$PWD" ] && [ -d "$cwd" ] && builtin cd -- "$cwd"'
+        echo '    command rm -f -- "$tmp"'
+        echo '}'
     } >> "$HOME/.zshrc"
+}
+
+install_binaries() {
+    # apt 无 yazi/choose，取官方 release 二进制装入 /usr/local/bin
+    local tmp
+    tmp="$(mktemp -d)"
+
+    # yazi 终端文件管理器（zip 内为同名子目录，含 yazi 与 ya 两个可执行文件）
+    curl -fsSL -o "$tmp/yazi.zip" \
+        "https://github.com/sxyazi/yazi/releases/latest/download/yazi-x86_64-unknown-linux-gnu.zip"
+    unzip -q "$tmp/yazi.zip" -d "$tmp"
+    sudo install -m 755 "$tmp/yazi-x86_64-unknown-linux-gnu/yazi" /usr/local/bin/yazi
+    sudo install -m 755 "$tmp/yazi-x86_64-unknown-linux-gnu/ya" /usr/local/bin/ya
+
+    # choose（cut 的人性化替代，裸 ELF 二进制，无需解压）
+    curl -fsSL -o "$tmp/choose" \
+        "https://github.com/theryangeary/choose/releases/latest/download/choose-x86_64-unknown-linux-gnu"
+    sudo install -m 755 "$tmp/choose" /usr/local/bin/choose
 }
 
 main() {
@@ -97,10 +128,14 @@ main() {
         hyperfine \
         sd \
         lazygit \
-        xh
+        btop \
+        du-dust \
+        duf \
+        procs
 
     tldr --update || true # 预热 tealdeer 离线缓存，网络失败不致命
 
+    install_binaries
     setup_git
     configure_zshrc
 }

--- a/debian/tools/node.sh
+++ b/debian/tools/node.sh
@@ -2,39 +2,16 @@
 
 set -euo pipefail
 
-get_nvm_latest() {
-    curl -fsSIL -o /dev/null -w '%{url_effective}' 'https://github.com/nvm-sh/nvm/releases/latest' | sed -E 's#.*/tag/v?([^/]+)$#\1#'
-}
-
-install_nvm() {
-    local version
-    version="$(get_nvm_latest)"
-    if [[ -z $version ]]; then
-        echo "Failed to determine the latest nvm version." >&2
-        return 1
-    fi
-
-    if [[ -s "$HOME/.zshrc" ]]; then
-        echo >> "$HOME/.zshrc"
-    fi
-
-    echo -n "# NVM" >> "$HOME/.zshrc"
-
-    # 下载并安装 nvm：
-    curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/v$version/install.sh" | bash
-}
-
 main() {
     sudo apt-get update
     sudo apt-get install -y build-essential
 
-    install_nvm
-
-    # shellcheck source=/dev/null
-    source "$HOME/.nvm/nvm.sh"
-    nvm install node
-
-    # sed -i '/^plugins=(/s/)/ node npm nvm)/' "$HOME/.zshrc"
+    # NodeSource LTS 官方源（版本比 Debian 自带更新，nodejs 自带 npm）。
+    # 系统级安装：node 落到 /usr/bin、对任何进程可见——Claude Code 的 node
+    # plugin（如 copilot-api agent-inject 的 hooks）由非交互进程直接以裸
+    # `node` 拉起，必须在系统 PATH 里，故不用 nvm。
+    curl -fsSL "https://deb.nodesource.com/setup_lts.x" | sudo -E bash -
+    sudo apt-get install -y nodejs
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then


### PR DESCRIPTION
## 现代 CLI 工具集增补与清理

按「社区高口碑/事实标准 + 卸载成本低」门槛，结合本地 Mac → ssh → 容器的开发场景，对 --command-utils 现代终端工具做一轮增补与清理。

### 新增
- **utils.sh**：yazi、choose（官方 release 二进制 → /usr/local/bin）、btop、dust、duf、procs（apt）、fzf-tab（omz 插件，头插保证早于 zsh-autosuggestions / zsh-syntax-highlighting 加载）、yazi 的 y() shell wrapper
- **app/docker.sh**：--app-docker 附带安装 lazydocker
- **command/omz.sh**：基线插件改为「内置在前、第三方在后」字典序，纳入内置 extract / aliases / dirhistory

### 变更 / 移除
- **tools/node.sh**：nvm → 系统级 node（NodeSource LTS）——Claude Code 的 node plugin 由非交互进程以裸 node 拉起，需在系统 PATH
- 移除 xh

### 验证
- bash -n + shellcheck 通过（仅既有 docker keyring 的 SC1091 info 级提示）
- 实测 yazi 官方 y() wrapper 逐字生成、最终 plugins=() 加载顺序正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)
