### PR TITLE
refactor: 拆分 Windows 暂存配置

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ Three independent setup trees, selected by `--setup`:
 adaptation. No `--setup` value reaches it and nothing runs it; `windows-wip/code/{csharp,powershell}.sh`
 are still the Debian `apt` versions they were before being moved out of `debian/code/`.
 
+`debian/vscode/` and `windows-wip/vscode/` are reference data, not dispatcher components — no
+script installs them (`--app-vscode` → `debian/app/vscode.sh` only inserts the omz `vscode` plugin).
+`windows-wip/vscode/` holds only the C#/PowerShell delta on top of `debian/vscode/`.
+
 ### The dispatcher pattern
 
 1. Env-var defaults with override: `export FOO="${FOO:-0}"`. The platform roots `debian/main.sh`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,10 @@ Three independent setup trees, selected by `--setup`:
 - `container/` — builds and runs a Docker dev container (`dev-container`) or the
   `copilot-api` image.
 
+`windows-wip/` is **not** a setup tree — it is a staging area for scripts awaiting Windows
+adaptation. No `--setup` value reaches it and nothing runs it; `windows-wip/code/{csharp,powershell}.sh`
+are still the Debian `apt` versions they were before being moved out of `debian/code/`.
+
 ### The dispatcher pattern
 
 1. Env-var defaults with override: `export FOO="${FOO:-0}"`. The platform roots `debian/main.sh`

--- a/README.md
+++ b/README.md
@@ -31,26 +31,24 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
         [--flag]
 ```
 
-| main args           | script args                               |
-| ------------------- | ----------------------------------------- |
-| `--agent-claude`    | `--agent-claude-copilot-api`              |
-|                     | `--agent-claude-anthropic-base-url <v>`   |
-|                     | `--agent-claude-anthropic-auth-token <v>` |
-| `--app-docker`      |                                           |
-| `--app-github`      |                                           |
-| `--app-micro`       |                                           |
-| `--app-tmux`        |                                           |
-| `--app-vscode`      |                                           |
-| `--code-bash`       |                                           |
-| `--code-csharp`     |                                           |
-| `--code-go`         |                                           |
-| `--code-powershell` |                                           |
-| `--code-python`     |                                           |
-| `--code-rust`       |                                           |
-| `--command-utils`   | `--command-utils-git-user-name <v>`       |
-|                     | `--command-utils-git-user-email <v>`      |
-| `--tools-node`      |                                           |
-| `--tools-protobuf`  |                                           |
+| main args          | script args                               |
+| ------------------ | ----------------------------------------- |
+| `--agent-claude`   | `--agent-claude-copilot-api`              |
+|                    | `--agent-claude-anthropic-base-url <v>`   |
+|                    | `--agent-claude-anthropic-auth-token <v>` |
+| `--app-docker`     |                                           |
+| `--app-github`     |                                           |
+| `--app-micro`      |                                           |
+| `--app-tmux`       |                                           |
+| `--app-vscode`     |                                           |
+| `--code-bash`      |                                           |
+| `--code-go`        |                                           |
+| `--code-python`    |                                           |
+| `--code-rust`      |                                           |
+| `--command-utils`  | `--command-utils-git-user-name <v>`       |
+|                    | `--command-utils-git-user-email <v>`      |
+| `--tools-node`     |                                           |
+| `--tools-protobuf` |                                           |
 
 ## 3. Container
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 - [1. MacOS](#1-macos)
 - [2. Debian](#2-debian)
 - [3. Container](#3-container)
-- [4. VSCode](#4-vscode)
 
 ## 1. MacOS
 
@@ -50,6 +49,10 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
 | `--tools-node`     |                                           |
 | `--tools-protobuf` |                                           |
 
+```bash
+xargs -L1 code --install-extension < debian/vscode/extensions.txt
+```
+
 ## 3. Container
 
 ```bash
@@ -64,9 +67,3 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
 |                         | `--image-tag <v>`    |
 |                         | `(debian-flag)`      |
 | `--image copilot-api`   | `--copilot-api-auth` |
-
-## 4. VSCode
-
-```bash
-xargs -L1 code --install-extension < vscode/extensions.txt
-```

--- a/debian/main.sh
+++ b/debian/main.sh
@@ -13,9 +13,7 @@ export APP_TMUX="${APP_TMUX:-0}"
 export APP_VSCODE="${APP_VSCODE:-0}"
 
 export CODE_BASH="${CODE_BASH:-0}"
-export CODE_CSHARP="${CODE_CSHARP:-0}"
 export CODE_GO="${CODE_GO:-0}"
-export CODE_POWERSHELL="${CODE_POWERSHELL:-0}"
 export CODE_PYTHON="${CODE_PYTHON:-0}"
 export CODE_RUST="${CODE_RUST:-0}"
 
@@ -58,16 +56,8 @@ parse_args() {
                 CODE_BASH=1
                 shift
                 ;;
-            --code-csharp)
-                CODE_CSHARP=1
-                shift
-                ;;
             --code-go)
                 CODE_GO=1
-                shift
-                ;;
-            --code-powershell)
-                CODE_POWERSHELL=1
                 shift
                 ;;
             --code-python)
@@ -130,16 +120,8 @@ main() {
         bash "./code/bash.sh" "$@"
     fi
 
-    if [[ $CODE_CSHARP == "1" ]]; then
-        bash "./code/csharp.sh" "$@"
-    fi
-
     if [[ $CODE_GO == "1" ]]; then
         bash "./code/go.sh" "$@"
-    fi
-
-    if [[ $CODE_POWERSHELL == "1" ]]; then
-        bash "./code/powershell.sh" "$@"
     fi
 
     if [[ $CODE_PYTHON == "1" ]]; then

--- a/debian/vscode/extensions.txt
+++ b/debian/vscode/extensions.txt
@@ -2,7 +2,6 @@ anthropic.claude-code
 charliermarsh.ruff
 cheshirekow.cmake-format
 christian-kohler.path-intellisense
-csharpier.csharpier-vscode
 davidanson.vscode-markdownlint
 docker.docker
 drblury.protobuf-vsc
@@ -15,18 +14,15 @@ llvm-vs-code-extensions.vscode-clangd
 mads-hartmann.bash-ide-vscode
 ms-azuretools.vscode-containers
 ms-ceintl.vscode-language-pack-zh-hans
-ms-dotnettools.csdevkit
-ms-dotnettools.csharp
-ms-dotnettools.vscode-dotnet-runtime
 ms-python.debugpy
 ms-python.python
 ms-python.vscode-pylance
+ms-python.vscode-python-envs
 ms-vscode-remote.remote-containers
 ms-vscode-remote.remote-ssh
 ms-vscode-remote.remote-ssh-edit
 ms-vscode.cmake-tools
 ms-vscode.cpp-devtools
-ms-vscode.powershell
 ms-vscode.remote-explorer
 pkief.material-icon-theme
 redhat.vscode-xml

--- a/debian/vscode/settings.json
+++ b/debian/vscode/settings.json
@@ -1,10 +1,4 @@
 {
-    "[csharp]": {
-        "editor.defaultFormatter": "csharpier.csharpier-vscode",
-        "editor.rulers": [
-            100
-        ]
-    },
     "[dockercompose]": {
         "editor.defaultFormatter": "redhat.vscode-yaml"
     },
@@ -39,23 +33,10 @@
         "workbench.action.tasks.configureTaskRunner",
         "workbench.action.tasks.runTask"
     ],
-    "csharp.inlayHints.enableInlayHintsForImplicitObjectCreation": true,
-    "csharp.inlayHints.enableInlayHintsForImplicitVariableTypes": true,
-    "csharp.inlayHints.enableInlayHintsForLambdaParameterTypes": true,
-    "csharp.inlayHints.enableInlayHintsForTypes": true,
     "diffEditor.hideUnchangedRegions.enabled": true,
     "diffEditor.ignoreTrimWhitespace": false,
     "docker.extension.dockerEngineAvailabilityPrompt": false,
     "docker.extension.enableComposeLanguageServer": true,
-    "dotnet.formatting.organizeImportsOnFormat": true,
-    "dotnet.inlayHints.enableInlayHintsForIndexerParameters": true,
-    "dotnet.inlayHints.enableInlayHintsForLiteralParameters": true,
-    "dotnet.inlayHints.enableInlayHintsForObjectCreationParameters": true,
-    "dotnet.inlayHints.enableInlayHintsForOtherParameters": true,
-    "dotnet.inlayHints.enableInlayHintsForParameters": true,
-    "dotnet.inlayHints.suppressInlayHintsForParametersThatDifferOnlyBySuffix": true,
-    "dotnet.inlayHints.suppressInlayHintsForParametersThatMatchArgumentName": true,
-    "dotnet.inlayHints.suppressInlayHintsForParametersThatMatchMethodIntent": true,
     "editor.fontFamily": "Fira Code",
     "editor.fontLigatures": true,
     "editor.formatOnSave": true,
@@ -81,24 +62,20 @@
     "files.readonlyInclude": {
         "**/.cargo/git/**": true, // Rust
         "**/.cargo/registry/**": true, // Rust
-        "**/.nuget/packages/**": true, // C#
         "**/.rustup/**": true, // Rust
         "**/go/pkg/mod/**": true, // Go
         "**/lib/python*/**": true, // Python
         "**/sdk/go*/src/**": true, // Go
         "**/typeshed-fallback/**": true, // Python
         "/usr/include/**": true, // C/C++
-        "/usr/lib/dotnet/**": true, // C#
         "/usr/lib/gcc/**": true, // C/C++
         "/usr/lib64/gcc/**": true, // C/C++
         "/usr/local/go/src/**": true, // Go
-        "/usr/local/include/**": true, // C/C++
-        "/usr/share/dotnet/**": true // C#
+        "/usr/local/include/**": true // C/C++
     },
     "git.autofetch": true,
     "git.confirmSync": false,
     "git.enableSmartCommit": true,
-    "github.copilot.chat.claudeAgent.enabled": false,
     "github.copilot.chat.localeOverride": "zh-CN",
     "go.inlayHints.assignVariableTypes": true,
     "go.inlayHints.compositeLiteralFields": true,
@@ -120,16 +97,6 @@
     "markdown-preview-enhanced.previewTheme": "one-dark.css",
     "markdown.extension.toc.levels": "2..6",
     "oneDarkPro.bold": true,
-    "powershell.codeFormatting.autoCorrectAliases": true,
-    "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
-    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
-    "powershell.codeFormatting.preset": "OTBS",
-    "powershell.codeFormatting.trimWhitespaceAroundPipe": true,
-    "powershell.codeFormatting.useConstantStrings": true,
-    "powershell.codeFormatting.useCorrectCasing": true,
-    "powershell.codeFormatting.whitespaceBetweenParameters": true,
-    "powershell.integratedConsole.showOnStartup": false,
-    "powershell.integratedConsole.startInBackground": true,
     "protobuf.autoDetection.prompted": true,
     "python.analysis.autoImportCompletions": true,
     "python.analysis.completeFunctionParens": true,

--- a/windows-wip/code/csharp.sh
+++ b/windows-wip/code/csharp.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 get_version_id() (
-    source /etc/os-release
+    source '/etc/os-release'
     echo "$VERSION_ID"
 )
 
@@ -19,8 +19,8 @@ add_repo() {
     local version_id
     version_id="$(get_version_id)"
 
-    curl -fsSL "https://packages.microsoft.com/config/debian/$version_id/packages-microsoft-prod.deb" -o /tmp/packages-microsoft-prod.deb
-    sudo dpkg -i /tmp/packages-microsoft-prod.deb
+    curl -fsSL "https://packages.microsoft.com/config/debian/$version_id/packages-microsoft-prod.deb" -o '/tmp/packages-microsoft-prod.deb'
+    sudo dpkg -i '/tmp/packages-microsoft-prod.deb'
 }
 
 install_dotnet_sdk() {
@@ -29,7 +29,7 @@ install_dotnet_sdk() {
     local version
     version="$(get_dotnet_latest)"
     if [[ -z $version ]]; then
-        echo "Failed to determine the latest .NET SDK version." >&2
+        echo 'Failed to determine the latest .NET SDK version.' >&2
         return 1
     fi
 
@@ -51,7 +51,7 @@ set_env() {
         echo 'export PATH="$HOME/.dotnet/tools:$PATH"'
     } >> "$HOME/.zshrc"
 
-    sed -i '/^plugins=(/s/)/ dotnet)/' "$HOME/.zshrc"
+    sed -i '/^plugins=(/s/zsh-syntax-highlighting/dotnet &/' "$HOME/.zshrc"
 }
 
 main() {

--- a/windows-wip/code/powershell.sh
+++ b/windows-wip/code/powershell.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 get_version_id() (
-    source /etc/os-release
+    source '/etc/os-release'
     echo "$VERSION_ID"
 )
 
@@ -11,8 +11,8 @@ add_repo() {
     local version_id
     version_id="$(get_version_id)"
 
-    curl -fsSL "https://packages.microsoft.com/config/debian/$version_id/packages-microsoft-prod.deb" -o /tmp/packages-microsoft-prod.deb
-    sudo dpkg -i /tmp/packages-microsoft-prod.deb
+    curl -fsSL "https://packages.microsoft.com/config/debian/$version_id/packages-microsoft-prod.deb" -o '/tmp/packages-microsoft-prod.deb'
+    sudo dpkg -i '/tmp/packages-microsoft-prod.deb'
 }
 
 install_powershell() {

--- a/windows-wip/vscode/extensions.txt
+++ b/windows-wip/vscode/extensions.txt
@@ -1,0 +1,5 @@
+csharpier.csharpier-vscode
+ms-dotnettools.csdevkit
+ms-dotnettools.csharp
+ms-dotnettools.vscode-dotnet-runtime
+ms-vscode.powershell

--- a/windows-wip/vscode/settings.json
+++ b/windows-wip/vscode/settings.json
@@ -1,0 +1,35 @@
+{
+    "[csharp]": {
+        "editor.defaultFormatter": "csharpier.csharpier-vscode",
+        "editor.rulers": [
+            100
+        ]
+    },
+    "csharp.inlayHints.enableInlayHintsForImplicitObjectCreation": true,
+    "csharp.inlayHints.enableInlayHintsForImplicitVariableTypes": true,
+    "csharp.inlayHints.enableInlayHintsForLambdaParameterTypes": true,
+    "csharp.inlayHints.enableInlayHintsForTypes": true,
+    "dotnet.formatting.organizeImportsOnFormat": true,
+    "dotnet.inlayHints.enableInlayHintsForIndexerParameters": true,
+    "dotnet.inlayHints.enableInlayHintsForLiteralParameters": true,
+    "dotnet.inlayHints.enableInlayHintsForObjectCreationParameters": true,
+    "dotnet.inlayHints.enableInlayHintsForOtherParameters": true,
+    "dotnet.inlayHints.enableInlayHintsForParameters": true,
+    "dotnet.inlayHints.suppressInlayHintsForParametersThatDifferOnlyBySuffix": true,
+    "dotnet.inlayHints.suppressInlayHintsForParametersThatMatchArgumentName": true,
+    "dotnet.inlayHints.suppressInlayHintsForParametersThatMatchMethodIntent": true,
+    "files.readonlyInclude": {
+        "**/.nuget/packages/**": true, // C#
+        "C:/Program Files/dotnet/**": true // C#
+    },
+    "powershell.codeFormatting.autoCorrectAliases": true,
+    "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
+    "powershell.codeFormatting.preset": "OTBS",
+    "powershell.codeFormatting.trimWhitespaceAroundPipe": true,
+    "powershell.codeFormatting.useConstantStrings": true,
+    "powershell.codeFormatting.useCorrectCasing": true,
+    "powershell.codeFormatting.whitespaceBetweenParameters": true,
+    "powershell.integratedConsole.showOnStartup": false,
+    "powershell.integratedConsole.startInBackground": true
+}


### PR DESCRIPTION
## 概要

- 将 C# 与 PowerShell 暂存脚本从 Debian setup tree 迁入 `windows-wip/code/`，并移除 Debian dispatcher 中对应的 flags 与调用
- 将顶层 VS Code 配置拆为 `debian/vscode/` 基线和 `windows-wip/vscode/` 的 C#/PowerShell 增量
- 更新 README 与架构说明，明确 `windows-wip/` 不是可执行的 setup tree

## 验证

- `git diff --check master...feat/windows`
- `bash -n debian/main.sh windows-wip/code/csharp.sh windows-wip/code/powershell.sh`
- `shellcheck -e SC1091,SC2153 debian/main.sh windows-wip/code/csharp.sh windows-wip/code/powershell.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
