### PR TITLE
feat(modern-cli): 添加现代命令行工具集

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,24 +52,25 @@ Three independent setup trees, selected by `--setup`:
   *terminal client / jump box*, not a dev machine: its omz plugin list is picked around the
   ssh-to-remote workflow (connect, manage keys, move files) and deliberately omits `git`.
 - `debian/` — the richest tree; installs zsh + oh-my-zsh unconditionally, then a
-  matrix of optional components. `--command-utils` is now a nested dispatcher:
-  `command/modern_cli/main.sh` still installs the bulk command-utility package set and downloads
-  yazi / `ya` and `choose` into `/usr/local/bin`, then runs `modern_cli/bat/`,
-  `modern_cli/fdfind.sh`, `modern_cli/micro/` and `modern_cli/tldr.sh`; each child installs its own
-  package and config and carries no flag of its own. One component is shaped unusually: `--app-git` deliberately spans all three
-  layers of a single concern instead of being split by kind: it installs the tooling (`gh` from the
-  official apt repo, `git-delta`, `lazygit`), writes the global git config, owns the `gh auth login`
-  block in `01-first_run.zsh`, and owns `~/.config/lazygit/config.yml`. That is why `git-delta` /
-  `lazygit` are absent from `command/modern_cli/main.sh`'s package list, and why the delta pager
-  config is unconditional — the script that writes it is the one that installed delta, so no
-  cross-flag read is needed. That last drop point is why the component lives in `debian/app/git/`
-  (`main.sh` + `config.yml`) rather than as a flat `app/git.sh`: it is the
-  `debian/command/modern_cli/micro/` shape, `install -Dm 644 './config.yml'
-  "$HOME/.config/lazygit/config.yml"` and all. A shipped template rather than an `echo` block because
-  it is six lines of static YAML with no interpolation. It owns only the Nerd Fonts version,
-  side-panel width and delta pager; `nerdFontsVersion: "3"` must stay a string because the unquoted
-  integer fails the unmarshal. Five things about lazygit are worth knowing before touching that
-  file.
+  matrix of optional components. `--command-modern-cli` is a nested dispatcher, the same shape as
+  `--app-claude`: `command/modern_cli/main.sh` installs the bulk of the CLI tools itself, downloads
+  yazi / `ya` and `choose`, then runs four sub-scripts — `modern_cli/bat/`,
+  `modern_cli/fdfind.sh`, `modern_cli/micro/` and `modern_cli/tldr.sh` — each still installing its
+  own packages and owning whatever config that tool needs, none of them carrying a flag of its own.
+  One component is shaped unusually: `--app-git`
+  deliberately spans all three layers of a single concern instead of being split by kind: it
+  installs the tooling (`gh` from the official apt repo, `git-delta`, `lazygit`), writes the global
+  git config, owns the `gh auth login` block in `01-first_run.zsh`, and owns
+  `~/.config/lazygit/config.yml`. That is why `git-delta` / `lazygit` are absent from
+  `--command-modern-cli`'s package list, and why the delta pager config is unconditional — the
+  script that writes it is the one that installed delta, so no cross-flag read is needed.
+  That last drop point is why the component lives in `debian/app/git/` (`main.sh` + `config.yml`)
+  rather than as a flat `app/git.sh`: it is the `debian/command/modern_cli/micro/` shape,
+  `install -Dm 644 './config.yml' "$HOME/.config/lazygit/config.yml"` and all. A shipped template
+  rather than an `echo` block because it is six lines of static YAML with no interpolation. It owns
+  only the Nerd Fonts version, side-panel width and delta pager; `nerdFontsVersion: "3"` must stay a
+  string because the unquoted integer fails the unmarshal. Five things about lazygit are worth
+  knowing before touching that file.
 
   **lazygit has no plugin system.** The entire extension surface is that one config file:
   `customCommands`, the `git.paging` pager, the `os.*` command hooks, `services` for self-hosted
@@ -119,11 +120,13 @@ Three independent setup trees, selected by `--setup`:
     p10k-media's bundled `MesloLGS NF` is Nerd Fonts **v2.3.3** (not rebuilt since 2023-04-03) and
     covers 270/324 of lazygit's icons, against 321/328 for Nerd Fonts v3.4.0's own `Meslo.zip`.
     `~/.p10k.zsh` declaring `POWERLEVEL9K_MODE=nerdfont-v3` is the signal that the v3 font is the
-    one installed.
+    one installed — also the prerequisite behind `debian/todo.md`'s eza `icons` item.
 
   `modern_cli/bat/` installs the `bat` package, makes the `~/.local/bin/bat` symlink over Debian's
   `batcat`, and ships `~/.config/bat/config`. The symlinked name needs one `compdef bat=batcat`
-  line, which `custom_env.sh` writes. Its two config lines are verbatim the two options bat's own
+  line, which `custom_env.sh` writes — see the `compinit` discussion under Conventions for why that
+  line is required and an alias would not have been. Four things about `bat/config` are worth
+  knowing before touching it. Its two lines are verbatim the two options bat's own
   `--generate-config-file` template leaves commented out, so it diffs cleanly against upstream. Its
   format is a shell word-split per line, so — unlike micro's JSON — it takes `#` comments,
   whole-line *or* trailing, which is what lets it carry the managed-by header; that same splitting
@@ -131,8 +134,8 @@ Three independent setup trees, selected by `--setup`:
   `git/config.yml`'s. Where micro and lazygit silently ignore an unknown key, bat **hard-errors**
   on one — the file's words are prepended to argv, so clap rejects it and *every* `bat` run fails
   until it is removed. And it must be the **only** place bat's theme is set: `BAT_THEME` in the
-  environment outranks the config file. delta is unaffected either way — its theme comes from
-  gitconfig (`delta.syntax-theme`), not from `BAT_THEME`.
+  environment outranks the config file (verified in both directions). delta is unaffected either
+  way — its theme comes from gitconfig (`delta.syntax-theme`), not from `BAT_THEME`.
 
   With `bat/config` the rule is uniform across the repo: **a tool's own config file is always a
   shipped artifact, never an `echo` block.** `micro/settings.json`, `git/config.yml` and
@@ -147,6 +150,29 @@ Three independent setup trees, selected by `--setup`:
   what removed `link_binaries()` from `main.sh` — `fd` was its only entry. Unlike bat it needs no
   `compdef` line, because Debian's `_fd` declares `#compdef fd` and the symlinked name is therefore
   already registered.
+
+  `glow` deliberately stays in `modern_cli/main.sh`'s bulk apt list rather than becoming a directory
+  component: setup-env owns no Glow config. Trixie ships Glow 2.0.0 with Glamour 0.8.0; the generated
+  `~/.config/glow/glow.yml` already selects `style: "auto"`, `mouse: false`, `pager: false` and
+  `width: 80`, and none needs a repo-wide override. The non-default switches are not general
+  improvements either. `--all` only expands the TUI's Markdown search to the dotfiles,
+  `node_modules` and `GOPATH` it normally ignores; TUI line numbers count rendered display lines,
+  not source lines; and preserved newlines are consumed by the TUI pager's Glamour path, useful for
+  poetry or hand-laid-out notes but harmful to normal Markdown reflow. Keep all three opt-in.
+
+  Glow has no plugin API. Glamour 0.8.0's built-in top-level styles are `auto`, `ascii`, `dark`,
+  `dracula`, `tokyo-night`, `light`, `notty` and `pink`; One Dark is not one of them. As of
+  2026-08-10 the organised community themes are other palettes, while the One Dark files found are
+  unmaintained or lack a reusable licence, so this tree ships no Glow stylesheet. That also leaves
+  no reason for a Glow alias, helper function, completion artifact or global `GLOW_*` /
+  `GLAMOUR_*` setting; the later omz-plugin rejection remains the shell-side half of this choice.
+
+  Paging stays opt-in too. `glow -p` sends the rendered document to `$PAGER`, falling back to
+  `less -r`; `PAGER='less -R' glow -p FILE.md` is the safer one-shot form because `-R` passes ANSI
+  colour sequences without allowing every control character. Do not export `PAGER='less -R'`:
+  pager options belong in `$LESS` (the `APP_TMUX` block already owns this tree's `LESS` value), and
+  a global `$PAGER` changes unrelated programs. Glow parses Markdown, not roff or Git patches, so it
+  is not a `MANPAGER`, Git pager or replacement for delta either.
 
   `modern_cli/tldr.sh` is the smallest: it installs `tealdeer` (leaving
   `~/.config/tealdeer/config.toml` unseeded at its defaults), warms the offline page cache with
@@ -171,6 +197,11 @@ script installs them (`--app-vscode` on debian only adds the omz `vscode` plugin
 `windows-wip/vscode/` holds only the C#/PowerShell delta on top of `debian/vscode/`; `README.md`
 documents the manual `code --install-extension` step and the `files.readonlyInclude` merge caveat.
 
+`debian/todo.md` is the debian tree's pending-work list, carrying only what is still undone, each
+item with its current state, the fix, and the upstream citation behind it. Everything already
+settled lives in this file instead; the two are meant to be read together, and an item that lands
+here should leave `debian/todo.md`.
+
 ### The dispatcher pattern
 
 1. Env-var defaults with override: `export FOO="${FOO:-0}"`. The platform roots `debian/main.sh`
@@ -185,8 +216,8 @@ documents the manual `code --install-extension` step and the `files.readonlyIncl
    an app, never the reverse — and the `export` block and `parse_args()`'s cases repeat it, so the
    file reads top-to-bottom in the order it runs. Every gate runs exactly one script; a component
    made of several scripts nests them under its own directory and lets its `main.sh` run them
-   (`--command-utils`, `--app-claude`). Exporting is a deliberate cross-cutting mechanism: a leaf
-   can read *another* component's flag to add integration config only when both are enabled —
+   (`--command-modern-cli`, `--app-claude`). Exporting is a deliberate cross-cutting mechanism: a
+   leaf can read *another* component's flag to add integration config only when both are enabled —
    e.g. `tmux.sh` reads `APP_CLAUDE` (Claude Code passthrough / extended-keys when `--app-tmux` +
    `--app-claude`). That env read is intentional, not a missing `parse_args`. The
    `command/omz_custom/` scripts read component flags for a different reason: they *own* drop
@@ -334,11 +365,11 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
 - **Every GitHub release download goes through `releases/latest/download/<asset>`.** A tag never
   appears in a URL. What decides whether any version resolution happens at all is the *asset
   filename*. `choose-x86_64-unknown-linux-gnu` and `yazi-x86_64-unknown-linux-gnu.zip` carry no
-  version, so `command/modern_cli/main.sh` downloads both directly from pure literal URLs — single-quoted,
-  per the quoting rule — with no helper at all. `protoc-35.1-linux-x86_64.zip` embeds one, so
-  `tools/protobuf.sh` still resolves it, but only to build the *filename*, never a
-  `/releases/download/v<tag>/` path. `get_protoc_latest()` is that resolver:
-  `curl -fsSIL -o /dev/null -w '%{url_effective}'` on `/releases/latest` piped through one
+  version, so `command/modern_cli/main.sh` downloads both directly from pure literal URLs —
+  single-quoted, per the quoting rule — with no helper at all. `protoc-35.1-linux-x86_64.zip`
+  embeds one, so `tools/protobuf.sh` still resolves it, but only to
+  build the *filename*, never a `/releases/download/v<tag>/` path. `get_protoc_latest()` is that
+  resolver: `curl -fsSIL -o /dev/null -w '%{url_effective}'` on `/releases/latest` piped through one
   `sed -E 's#.*/tag/v?([^/]+)$#\1#'` (the `v?` strips the tag prefix the asset name does not want),
   followed at the call site by an `if [[ -z $version ]]` guard, since a network failure yields an
   empty string rather than a non-zero exit and `set -e` cannot catch it. **Resolving a version only
@@ -391,12 +422,12 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   `append_plugin` once per remaining plugin (`colored-man-pages` first on debian, `brew` on macos),
   each optional one gated on its component's exported flag: `docker`/`docker-compose` on
   `APP_DOCKER`, `python`/`uv` on `CODE_PYTHON`, `eza`/`zoxide`/`fzf`/`fzf-tab` on
-  `COMMAND_UTILS`, and so on; on macos `ssh` on `COMMAND_SSH`, whose `~/.ssh/config` is written
-  later by `command/ssh.sh`. Leaving an optional plugin ungated hides that dependency and leaves a
-  silently no-op plugin behind whenever the component is off.
+  `COMMAND_MODERN_CLI`, and so on; on macos `ssh` on `COMMAND_SSH`, whose `~/.ssh/config` is
+  written later by `command/ssh.sh`. Leaving an optional plugin ungated hides that dependency and
+  leaves a silently no-op plugin behind whenever the component is off.
 
-  The installing component (`code/go.sh`, `app/docker.sh`, `command/modern_cli/main.sh`, …) keeps its installs
-  and its non-zsh config but must not touch `plugins=()` — nor `00-setup_env.zsh` or
+  The installing component (`code/go.sh`, `app/docker.sh`, `command/modern_cli/main.sh`, …) keeps its
+  installs and its non-zsh config but must not touch `plugins=()` — nor `00-setup_env.zsh` or
   `01-first_run.zsh`, which follow the same rule for the same reason. `omz_custom` runs second in
   the tree, so a plugin name reaches `.zshrc` *before* its tool is installed — harmless, since
   nothing reads the array until a shell starts, which is after setup ends.
@@ -440,9 +471,10 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
      uses. Unrelated and still required: `macos/main.sh`'s own `eval` line, which runs in the
      setup-time *bash* process so child scripts can find brew — no zsh plugin can reach that.
 
-  **The debian tree violates 1–3 whenever `--command-utils` is on**, and appends `z` (zsh-z)
+  **The debian tree violates 1–3 whenever `--command-modern-cli` is on**, and appends `z` (zsh-z)
   unconditionally even though `zoxide` then takes over the same command name. macos satisfies all
-  six today. Preserve those constraints when the debian array is eventually reordered.
+  six today. Both are pending the `--command-modern-cli` rework — `debian/todo.md` §1 and §2 hold
+  the analysis, the fix and the target array.
 
   Should *removing* a name from the array ever be needed again: delimit on spaces and parens
   (`s/(z /(/; s/ z / /; s/ z)/)/`), never `\<z\>`. `-` is not a word constituent, so `\<z\>` also
@@ -471,7 +503,7 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   | `PATH` and anything a non-interactive shell needs | `.zshenv` (see `code/go.sh`, `code/rust.sh`) |
 
   `compdef` is in row two rather than row four because `compinit` runs at l.127, well before
-  l.209 — `custom_env.sh`'s `COMMAND_UTILS` block writes `compdef bat=batcat` there. Two rules
+  l.209 — `custom_env.sh`'s `COMMAND_MODERN_CLI` block writes `compdef bat=batcat` there. Two rules
   govern that line and the symlinks around it: **`compinit` looks at a file only if its name
   matches `_*`**, and **it registers by the name on that file's `#compdef` first line, not by the
   file name and not by whether the command exists.** Debian's three packagers diverged along both
@@ -507,15 +539,16 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   `~/.local/bin` is the one `PATH` entry the repo does *not* write itself: `command/omz.sh:44`
   uncomments omz's own template line (`export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH`,
   `.zshrc` l.2), and `omz.sh` runs first in the tree — so any later component can drop a binary
-  there and have it resolve. `modern_cli/fdfind.sh`'s `fd` symlink,
-  `modern_cli/bat/main.sh`'s `bat` symlink and `tools/protobuf.sh`'s `protoc` all rely on that
-  placement, and none needs `sudo`. Being in `.zshrc`, the entry is interactive-only — enough for
-  the `(( $+commands[fd] ))` probes plugins do while `.zshrc` is still being sourced, but a
-  non-interactive `zsh -c` will not see it.
+  there and have it resolve. `modern_cli/fdfind.sh`'s `fd` symlink, `modern_cli/bat/main.sh`'s `bat`
+  symlink and `tools/protobuf.sh`'s `protoc` all rely on this, and it is why none of those placements
+  needs `sudo`. Being in `.zshrc` it is interactive-only — enough for the
+  `(( $+commands[fd] ))` probes plugins do while `.zshrc` is still being sourced (l.2 precedes the
+  `source $ZSH/oh-my-zsh.sh` at l.75), but a non-interactive `zsh -c` will not see it.
 
   Only `PYTHON_AUTO_VRUN` is in the first row today — `python.plugin.zsh:103` decides at load
   time whether to register the `chpwd` hook, and the plugin's own README says to set it "before
-  sourcing oh-my-zsh".
+  sourcing oh-my-zsh". `zstyle ':omz:plugins:eza' …` belongs there too (`eza.plugin.zsh:9-54`
+  builds its aliases at load time) and is pending — `debian/todo.md` §3.
 
   Row four earns its second clause from where the first row sits. `setup-env` is sourced at l.203
   — **after** `compinit` (l.127) and **after** `lib/*.zsh` (l.197) — so anything those two read is
@@ -576,16 +609,19 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   `main()` — the only write to that file anywhere in the tree, so a re-run rebuilds it instead of
   accumulating duplicate blocks, and no component can append behind its back. The unconditional
   section comes first, then one gated block per component, each headed by a `#` title, in the
-  order those components run in `debian/main.sh`: `COMMAND_UTILS` owns the `tree` alias, bat's
-  `compdef`, Editor selection and its `EDITOR="code --wait"` branch on `APP_VSCODE`, the Micro
-  runtime settings, and yazi's `y()` cwd-following wrapper; `APP_DOCKER` owns the `lzd` alias;
-  `APP_GIT` owns the `lg()` wrapper; and `APP_TMUX` owns mouse-friendly `LESS`. Block titles name the
-  *component concern*, not necessarily the executable — `# Git` rather than `# lazygit`, and
-  `# Editor` / `# Micro` within the command-utilities block. Intra-file order is cosmetic — the
+  order those components run in `debian/main.sh`: `COMMAND_MODERN_CLI` — one gate holding the
+  dispatcher integrations in one place (`# Modern CLI tools`; `# bat`, only `compdef bat=batcat`
+  because everything else bat needs lives in `~/.config/bat/config`; `# Editor` then `# Micro`,
+  with the `EDITOR="code --wait"` branch nested one level deeper on `APP_VSCODE`; `# yazi`, the
+  existing `y()` wrapper for the binary installed inline by `modern_cli/main.sh` — `fdfind.sh` and
+  `tldr.sh` contribute nothing) — then `APP_DOCKER` (`# Docker`, the
+  `lzd` alias), `APP_GIT` (`# Git`, the `lg()` wrapper) and `APP_TMUX` (`# tmux mouse scroll`).
+  Block titles name the *component*, not the tool, wherever the two differ — `# Git` rather than
+  `# lazygit` — matching `# Editor` / `# Micro` above them. Intra-file order is cosmetic — the
   whole file lands at l.209, after every plugin, which is exactly what lets a value here override
   one a plugin set — but following the dispatcher keeps it predictable. The `00-` prefix is load
-  order, not decoration: omz sources `$ZSH_CUSTOM/*.zsh` alphabetically, so a second file must pick
-  its number the same way.
+  order, not decoration: omz sources `$ZSH_CUSTOM/*.zsh` alphabetically, so a second file must
+  pick its number the same way.
 
   `lg` and `lzd` are the short commands lazygit's and lazydocker's own READMEs suggest, and both
   names were checked clear before being taken — nothing this tree installs or enables defines
@@ -673,9 +709,9 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
 - **`set -e` and trailing `[[ … ]] && cmd`.** A function whose *last* statement is a false
   conditional AND-list returns 1, and at the call site `set -e` takes that as a failure and exits
   — the guard inside the list only protects the `[[ … ]]` itself, not the function's exit status.
-  `install_plugin()` ends on `[[ $COMMAND_UTILS == '1' ]] && append_plugin 'fzf-tab'`, so without
-  a trailing `return 0` the entire default install path (`COMMAND_UTILS=0`) dies right there,
-  taking `install_theme`, the three env scripts and `debian/main.sh` down with it.
+  `install_plugin()` ends on `[[ $COMMAND_MODERN_CLI == '1' ]] && append_plugin 'fzf-tab'`, so
+  without a trailing `return 0` the entire default install path (`COMMAND_MODERN_CLI=0`) dies
+  right there, taking `install_theme`, the three env scripts and `debian/main.sh` down with it.
   Hence the explicit `return 0`. It hides nothing: any genuine failure inside the function already
   exits the script at the failing command, never reaching the `return`. Prefer it to "make sure
   the last line happens to be unconditional", which the next edit quietly breaks. The same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,25 +52,24 @@ Three independent setup trees, selected by `--setup`:
   *terminal client / jump box*, not a dev machine: its omz plugin list is picked around the
   ssh-to-remote workflow (connect, manage keys, move files) and deliberately omits `git`.
 - `debian/` — the richest tree; installs zsh + oh-my-zsh unconditionally, then a
-  matrix of optional components. `--command-utils` runs the flat `command/utils.sh`, which installs
-  the bulk command-utility package set (including bat, fd-find and tealdeer), warms the `tldr` cache,
-  and downloads yazi / `ya` and `choose` into `/usr/local/bin`. Micro remains an independent
-  component under
-  `debian/app/micro/`, gated by `APP_MICRO` / `--app-micro`. One component is shaped unusually:
-  `--app-git` deliberately spans all three layers of a single concern instead of being split by
-  kind: it installs the tooling (`gh` from the official apt repo, `git-delta`, `lazygit`), writes the
-  global git config, owns the `gh auth login` block in `01-first_run.zsh`, and owns
-  `~/.config/lazygit/config.yml`. That is why `git-delta` / `lazygit` are absent from
-  `command/utils.sh`'s package list, and why the delta pager config is unconditional — the script
-  that writes it is the one that installed delta, so no cross-flag read is needed.
-  That last drop point is why the component lives in `debian/app/git/` (`main.sh` + `config.yml`)
-  rather than as a flat `app/git.sh`: it follows the existing `debian/app/micro/` directory-component
-  shape, with a script beside a shipped config, and installs its template with
-  `install -Dm 644 './config.yml' "$HOME/.config/lazygit/config.yml"`. A shipped template rather than
-  an `echo` block because it is six lines of static YAML with no interpolation. It owns only the Nerd
-  Fonts version, side-panel width and delta pager; `nerdFontsVersion: "3"` must stay a string because
-  the unquoted integer fails the unmarshal. Five things about lazygit are worth knowing before
-  touching that file.
+  matrix of optional components. `--command-utils` is now a nested dispatcher:
+  `command/modern_cli/main.sh` still installs the bulk command-utility package set (including bat,
+  fd-find and tealdeer), warms the `tldr` cache, and downloads yazi / `ya` and `choose` into
+  `/usr/local/bin`, then runs `modern_cli/micro/` to install Micro and its config. The child carries
+  no flag of its own. One component is shaped unusually: `--app-git` deliberately spans all three
+  layers of a single concern instead of being split by kind: it installs the tooling (`gh` from the
+  official apt repo, `git-delta`, `lazygit`), writes the global git config, owns the `gh auth login`
+  block in `01-first_run.zsh`, and owns `~/.config/lazygit/config.yml`. That is why `git-delta` /
+  `lazygit` are absent from `command/modern_cli/main.sh`'s package list, and why the delta pager
+  config is unconditional — the script that writes it is the one that installed delta, so no
+  cross-flag read is needed. That last drop point is why the component lives in `debian/app/git/`
+  (`main.sh` + `config.yml`) rather than as a flat `app/git.sh`: it is the
+  `debian/command/modern_cli/micro/` shape, `install -Dm 644 './config.yml'
+  "$HOME/.config/lazygit/config.yml"` and all. A shipped template rather than an `echo` block because
+  it is six lines of static YAML with no interpolation. It owns only the Nerd Fonts version,
+  side-panel width and delta pager; `nerdFontsVersion: "3"` must stay a string because the unquoted
+  integer fails the unmarshal. Five things about lazygit are worth knowing before touching that
+  file.
 
   **lazygit has no plugin system.** The entire extension surface is that one config file:
   `customCommands`, the `git.paging` pager, the `os.*` command hooks, `services` for self-hosted
@@ -85,10 +84,10 @@ Three independent setup trees, selected by `--setup`:
   Copying master's `Custom_Pagers.md` produces config that does nothing here. Changing the install
   channel means rewriting that whole block.
 
-  **Unknown keys are silently ignored.** `app_config.go:202` is a bare
-  `yaml.Unmarshal(content, base)` with no `KnownFields(true)`, on master too. A key from a newer
-  version's docs neither errors nor gets stripped; it is invisible dead config that only a version
-  check finds — the YAML *syntax* check cannot see it either.
+  **Unknown keys are silently ignored — the same trap as micro's `truecolor`.**
+  `app_config.go:202` is a bare `yaml.Unmarshal(content, base)` with no `KnownFields(true)`, on
+  master too. A key from a newer version's docs neither errors nor gets stripped; it is invisible
+  dead config that only a version check finds — the YAML *syntax* check cannot see it either.
 
   **lazygit rewrites this file itself.** `app_config.go:221`'s `migrateUserConfig()` writes the
   file back when it finds a key it can migrate. None of 0.50.0's five migratable keys is one we
@@ -123,12 +122,12 @@ Three independent setup trees, selected by `--setup`:
     one installed.
 
   The same general config rule applies at this layer: **a tool's own config file is a shipped
-  artifact, never an `echo` block.** `app/micro/settings.json` is copied into place,
-  `app/git/config.yml` is installed with `install -Dm 644`, and `copilot_api/settings.json` is a
-  shipped template completed through `jq` interpolation. What is left to `echo` is only the files
-  this repo invented (`00-setup_env.zsh`, `01-first_run.zsh`, `setup-env.plugin.zsh`) and appends
-  into files an upstream installer or the shell already made (`tmux.conf.local`, `.zshenv`, the ssh
-  config) — plus the git config, which goes through `git config --global` and has no file to ship.
+  artifact, never an `echo` block.** `modern_cli/micro/settings.json` and `app/git/config.yml` land
+  through the same `install -Dm 644`, and `copilot_api/settings.json` is that plus `jq`
+  interpolation. What is left to `echo` is only the files this repo invented (`00-setup_env.zsh`,
+  `01-first_run.zsh`, `setup-env.plugin.zsh`) and appends into files an upstream installer or the
+  shell already made (`tmux.conf.local`, `.zshenv`, the ssh config) — plus the git config, which
+  goes through `git config --global` and has no file to ship.
 - `container/` — builds and runs a Docker dev container (`dev-container`) or the
   `copilot-api` image.
 
@@ -156,10 +155,9 @@ documents the manual `code --install-extension` step and the `files.readonlyIncl
    The grouping is dependency-shaped — a language toolchain (`--code-*`) can be a prerequisite for
    an app, never the reverse — and the `export` block and `parse_args()`'s cases repeat it, so the
    file reads top-to-bottom in the order it runs. Every gate runs exactly one script; a component
-   made of several scripts can nest them under its own directory and let its `main.sh` run them
-   (`--app-claude` does this, while `--command-utils` remains a flat script). Exporting is a
-   deliberate cross-cutting mechanism: a leaf can read *another* component's flag to add
-   integration config only when both are enabled —
+   made of several scripts nests them under its own directory and lets its `main.sh` run them
+   (`--command-utils`, `--app-claude`). Exporting is a deliberate cross-cutting mechanism: a leaf
+   can read *another* component's flag to add integration config only when both are enabled —
    e.g. `tmux.sh` reads `APP_CLAUDE` (Claude Code passthrough / extended-keys when `--app-tmux` +
    `--app-claude`). That env read is intentional, not a missing `parse_args`. The
    `command/omz_custom/` scripts read component flags for a different reason: they *own* drop
@@ -307,7 +305,7 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
 - **Every GitHub release download goes through `releases/latest/download/<asset>`.** A tag never
   appears in a URL. What decides whether any version resolution happens at all is the *asset
   filename*. `choose-x86_64-unknown-linux-gnu` and `yazi-x86_64-unknown-linux-gnu.zip` carry no
-  version, so `command/utils.sh` downloads both directly from pure literal URLs — single-quoted,
+  version, so `command/modern_cli/main.sh` downloads both directly from pure literal URLs — single-quoted,
   per the quoting rule — with no helper at all. `protoc-35.1-linux-x86_64.zip` embeds one, so
   `tools/protobuf.sh` still resolves it, but only to build the *filename*, never a
   `/releases/download/v<tag>/` path. `get_protoc_latest()` is that resolver:
@@ -316,7 +314,7 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   followed at the call site by an `if [[ -z $version ]]` guard, since a network failure yields an
   empty string rather than a non-zero exit and `set -e` cannot catch it. **Resolving a version only
   to write it straight back into the URL path is the tell that the step is dead weight** — that was
-  the older yazi path in `command/utils.sh`, with the bare number never used for anything.
+  the older yazi path in `command/modern_cli/main.sh`, with the bare number never used for anything.
 
   Two things this does *not* buy. It does not pin a version — `latest` is `latest` either way, so a
   re-run picks up whatever shipped since. And `latest` plus an explicit version in the asset name
@@ -368,7 +366,7 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   later by `command/ssh.sh`. Leaving an optional plugin ungated hides that dependency and leaves a
   silently no-op plugin behind whenever the component is off.
 
-  The installing component (`code/go.sh`, `app/docker.sh`, `command/utils.sh`, …) keeps its installs
+  The installing component (`code/go.sh`, `app/docker.sh`, `command/modern_cli/main.sh`, …) keeps its installs
   and its non-zsh config but must not touch `plugins=()` — nor `00-setup_env.zsh` or
   `01-first_run.zsh`, which follow the same rule for the same reason. `omz_custom` runs second in
   the tree, so a plugin name reaches `.zshrc` *before* its tool is installed — harmless, since
@@ -444,12 +442,12 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   | `PATH` and anything a non-interactive shell needs | `.zshenv` (see `code/go.sh`, `code/rust.sh`) |
 
   The `COMMAND_UTILS` runtime integration belongs in row two: its gated omz plugins provide eza,
-  fzf and zoxide integration, while `custom_env.sh` writes the `bat`, `fd` and `tree` aliases, adds
-  `micror` only when `APP_MICRO` is also enabled, and defines yazi's `y()` cwd-following wrapper.
-  `command/utils.sh` owns the packages and binaries but never appends shell startup files itself.
-  This tree deliberately uses zsh aliases for Debian's `batcat` / `fdfind` names; changing those
-  compatibility names to real executables or adding completion artifacts is a separate component
-  change.
+  fzf and zoxide integration, while `custom_env.sh` writes the `bat`, `fd` and `tree` aliases,
+  configures Editor and Micro, and defines yazi's `y()` cwd-following wrapper.
+  `command/modern_cli/main.sh` owns the bulk packages and binaries and dispatches Micro, but never
+  appends shell startup files itself. This tree deliberately uses zsh aliases for Debian's `batcat`
+  / `fdfind` names; changing those compatibility names to real executables or adding completion
+  artifacts is a separate component change.
 
   `~/.local/bin` is the one `PATH` entry the repo does *not* write itself: `command/omz.sh:44`
   uncomments omz's own template line (`export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH`,
@@ -522,15 +520,15 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   accumulating duplicate blocks, and no component can append behind its back. The unconditional
   section comes first, then one gated block per component, each headed by a `#` title, in the
   order those components run in `debian/main.sh`: `COMMAND_UTILS` owns the `bat`, `fd` and `tree`
-  aliases, the optional `micror` alias when `APP_MICRO` is also enabled, and yazi's `y()`
-  cwd-following wrapper; `APP_DOCKER` owns the `lzd` alias; `APP_GIT` owns the `lg()` wrapper;
-  `APP_MICRO` owns editor selection and the `EDITOR="code --wait"` branch nested one level deeper
-  on `APP_VSCODE`; and `APP_TMUX` owns mouse-friendly `LESS`. Block titles name the *component
-  concern*, not necessarily the executable — `# Git` rather than `# lazygit`, and `# Editor` for
-  the Micro editor block. Intra-file order is cosmetic — the whole file lands at l.209, after every
-  plugin, which is exactly what lets a value here override one a plugin set — but following the
-  dispatcher keeps it predictable. The `00-` prefix is load order, not decoration: omz sources
-  `$ZSH_CUSTOM/*.zsh` alphabetically, so a second file must pick its number the same way.
+  aliases, Editor selection and its `EDITOR="code --wait"` branch on `APP_VSCODE`, the Micro runtime
+  settings, and yazi's `y()` cwd-following wrapper; `APP_DOCKER` owns the `lzd` alias; `APP_GIT`
+  owns the `lg()` wrapper; and `APP_TMUX` owns mouse-friendly `LESS`. Block titles name the
+  *component concern*, not necessarily the executable — `# Git` rather than `# lazygit`, and
+  `# Editor` / `# Micro` within the command-utilities block. Intra-file order is cosmetic — the
+  whole file lands at l.209, after every plugin, which is exactly what lets a value here override
+  one a plugin set — but following the dispatcher keeps it predictable. The `00-` prefix is load
+  order, not decoration: omz sources `$ZSH_CUSTOM/*.zsh` alphabetically, so a second file must pick
+  its number the same way.
 
   `lg` and `lzd` are the short commands lazygit's and lazydocker's own READMEs suggest, and both
   names were checked clear before being taken — nothing this tree installs or enables defines
@@ -544,6 +542,17 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   `gui.go:882` writes the file on *every* quit, `q` recording `os.Getwd()` and `shift+Q` recording
   `gui.InitialDir`, so running `lg` from a subdirectory and quitting with `q` lands the shell at
   the repo root — `shift+Q` is the way back. (Verified against 0.50.0 under a pty.)
+
+  The `# Micro` block's `MICRO_TRUECOLOR=1` is the only way to get true color out of micro on
+  Debian, and it belongs there rather than in `micro/settings.json`: trixie ships micro 2.0.14,
+  whose option list (`micro -options`, and the v2.0.14 tag's own `runtime/help/options.md`) has no
+  `truecolor` key at all — upstream added one later, and even there it is the enum
+  `"auto"`/`"on"`/`"off"`, not a boolean. **micro silently ignores unknown keys in `settings.json`**
+  — a bogus option neither errors nor gets stripped when micro rewrites the file — so a wrong key
+  there is invisible dead config, and only a version check finds it. It matters because `one-dark`
+  is a hex colorscheme like every non-`-tc` scheme micro ships: without the variable micro emits
+  zero 24-bit sequences even under `COLORTERM=truecolor`, degrading the whole palette to 256-color
+  approximations — exactly what stops it matching VS Code's `One Dark Pro`.
 
   Every variable in the unconditional section would in fact *work* from `setup-env` too — each is
   either guarded by `(( ! ${+VAR} ))` or read at runtime. It sits after the plugins because that is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,11 +53,11 @@ Three independent setup trees, selected by `--setup`:
   ssh-to-remote workflow (connect, manage keys, move files) and deliberately omits `git`.
 - `debian/` — the richest tree; installs zsh + oh-my-zsh unconditionally, then a
   matrix of optional components. `--command-modern-cli` is a nested dispatcher, the same shape as
-  `--app-claude`: `command/modern_cli/main.sh` installs the bulk of the CLI tools itself, downloads
-  yazi / `ya` and `choose`, then runs four sub-scripts — `modern_cli/bat/`,
-  `modern_cli/fdfind.sh`, `modern_cli/micro/` and `modern_cli/tldr.sh` — each still installing its
-  own packages and owning whatever config that tool needs, none of them carrying a flag of its own.
-  One component is shaped unusually: `--app-git`
+  `--app-claude`: `command/modern_cli/main.sh` installs the bulk of the CLI tools itself, then runs
+  the five sub-scripts under it — `modern_cli/bat/`, `modern_cli/fdfind.sh`, `modern_cli/micro/`,
+  `modern_cli/tldr.sh` and `modern_cli/yazi.sh` — each still installing its own packages and owning
+  whatever config that tool needs, none of them carrying a flag of its own. One component is shaped
+  unusually: `--app-git`
   deliberately spans all three layers of a single concern instead of being split by kind: it
   installs the tooling (`gh` from the official apt repo, `git-delta`, `lazygit`), writes the global
   git config, owns the `gh auth login` block in `01-first_run.zsh`, and owns
@@ -167,12 +167,41 @@ Three independent setup trees, selected by `--setup`:
   no reason for a Glow alias, helper function, completion artifact or global `GLOW_*` /
   `GLAMOUR_*` setting; the later omz-plugin rejection remains the shell-side half of this choice.
 
+  The one planned integration is yazi's official `piper` recipe:
+  `CLICOLOR_FORCE=1 glow -w=$w -s=dark "$1"`. `dark` there is Glow's built-in style, not yazi's One
+  Dark flavor. Non-TTY output on Glow 2.x quantises the RGB colours used by parts of that style —
+  chiefly Chroma code highlighting — to ANSI/256 colours even with `CLICOLOR_FORCE=1`; layout,
+  emphasis and syntax categories are unchanged. Do not promise TrueColor parity until a released
+  Glow contains the still-open `--color=always` work, and do not fake a TTY or `TERM` meanwhile.
+
   Paging stays opt-in too. `glow -p` sends the rendered document to `$PAGER`, falling back to
   `less -r`; `PAGER='less -R' glow -p FILE.md` is the safer one-shot form because `-R` passes ANSI
   colour sequences without allowing every control character. Do not export `PAGER='less -R'`:
   pager options belong in `$LESS` (the `APP_TMUX` block already owns this tree's `LESS` value), and
   a global `$PAGER` changes unrelated programs. Glow parses Markdown, not roff or Git patches, so it
   is not a `MANPAGER`, Git pager or replacement for delta either.
+
+  `modern_cli/yazi.sh` fetches the latest release zip, installs the `yazi` / `ya` binaries into
+  `~/.local/bin`, installs the `_yazi` / `_ya` completions the zip already ships into
+  `$ZSH_CUSTOM/completions/`, brings its own `file` (yazi needs it for mime detection and the
+  Debian docker base image has none) and `unzip`, and owns the `y()` cwd-following wrapper in
+  `00-setup_env.zsh` — all of that in its own script rather than in the `modern_cli/main.sh` that
+  runs it, so that script's own `install_binaries()` covers only `choose`. Both drop points are
+  under `$HOME` and already on `PATH` / `fpath` (see the `~/.local/bin` note under Conventions and
+  `oh-my-zsh.sh:76`'s unconditional `fpath=(… $ZSH_CUSTOM/{functions,completions} …)`), so apart
+  from that one `apt-get` the component needs no `sudo`. Writing a per-component `_foo` there is
+  not the ownership violation that touching `00-setup_env.zsh` would be — no other component writes
+  that filename, so none of the duplicate-append hazards the `omz_custom` rule exists to prevent
+  apply. Its install channel is settled, the two obvious alternatives vetted and rejected.
+  **cargo** is out: yazi's MSRV is `1.95.0` against trixie's apt `cargo` 1.85.0 and backports'
+  1.94.1, so it would mean a ≥1.95 toolchain (117 MB) plus a 5–15 minute build to reproduce what
+  upstream CI already publishes — and `cargo install --force yazi-build`, the only command that
+  works, does its real work in a `build.rs` that `git clone`s and builds under `env::temp_dir()`
+  without ever cleaning up. The **official `.deb`** is out too: ffmpeg, imagemagick, poppler-utils,
+  7zip and `xsel|xclip|wl-clipboard` are hard `Depends:` — 200 new packages on a
+  `--no-install-recommends` dry run — and its assets carry only the bash completions. The zip is
+  the most complete artifact of the three: `scripts/build.sh` sets `YAZI_GEN_COMPLETIONS=1`, so its
+  `completions/` holds every shell, zsh included.
 
   `modern_cli/tldr.sh` is the smallest: it installs `tealdeer` (leaving
   `~/.config/tealdeer/config.toml` unseeded at its defaults), warms the offline page cache with
@@ -365,16 +394,16 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
 - **Every GitHub release download goes through `releases/latest/download/<asset>`.** A tag never
   appears in a URL. What decides whether any version resolution happens at all is the *asset
   filename*. `choose-x86_64-unknown-linux-gnu` and `yazi-x86_64-unknown-linux-gnu.zip` carry no
-  version, so `command/modern_cli/main.sh` downloads both directly from pure literal URLs —
-  single-quoted, per the quoting rule — with no helper at all. `protoc-35.1-linux-x86_64.zip`
-  embeds one, so `tools/protobuf.sh` still resolves it, but only to
+  version, so `command/modern_cli/main.sh` and `command/modern_cli/yazi.sh` download in one line
+  from a pure literal URL — single-quoted, per the quoting rule — with no helper at all.
+  `protoc-35.1-linux-x86_64.zip` embeds one, so `tools/protobuf.sh` still resolves it, but only to
   build the *filename*, never a `/releases/download/v<tag>/` path. `get_protoc_latest()` is that
   resolver: `curl -fsSIL -o /dev/null -w '%{url_effective}'` on `/releases/latest` piped through one
   `sed -E 's#.*/tag/v?([^/]+)$#\1#'` (the `v?` strips the tag prefix the asset name does not want),
   followed at the call site by an `if [[ -z $version ]]` guard, since a network failure yields an
   empty string rather than a non-zero exit and `set -e` cannot catch it. **Resolving a version only
   to write it straight back into the URL path is the tell that the step is dead weight** — that was
-  the older yazi path in `command/modern_cli/main.sh`, with the bare number never used for anything.
+  `command/modern_cli/yazi.sh` before, with the bare number never used for anything.
 
   Two things this does *not* buy. It does not pin a version — `latest` is `latest` either way, so a
   re-run picks up whatever shipped since. And `latest` plus an explicit version in the asset name
@@ -540,10 +569,11 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   uncomments omz's own template line (`export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH`,
   `.zshrc` l.2), and `omz.sh` runs first in the tree — so any later component can drop a binary
   there and have it resolve. `modern_cli/fdfind.sh`'s `fd` symlink, `modern_cli/bat/main.sh`'s `bat`
-  symlink and `tools/protobuf.sh`'s `protoc` all rely on this, and it is why none of those placements
-  needs `sudo`. Being in `.zshrc` it is interactive-only — enough for the
-  `(( $+commands[fd] ))` probes plugins do while `.zshrc` is still being sourced (l.2 precedes the
-  `source $ZSH/oh-my-zsh.sh` at l.75), but a non-interactive `zsh -c` will not see it.
+  symlink, `modern_cli/yazi.sh`'s `yazi` / `ya` and `tools/protobuf.sh`'s `protoc` all rely on this,
+  and it is why none of those placements needs `sudo`. Being in `.zshrc` it is
+  interactive-only — enough for the `(( $+commands[fd] ))` probes plugins do while `.zshrc` is
+  still being sourced (l.2 precedes the `source $ZSH/oh-my-zsh.sh` at l.75), but a non-interactive
+  `zsh -c` will not see it.
 
   Only `PYTHON_AUTO_VRUN` is in the first row today — `python.plugin.zsh:103` decides at load
   time whether to register the `chpwd` hook, and the plugin's own README says to set it "before
@@ -609,12 +639,12 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   `main()` — the only write to that file anywhere in the tree, so a re-run rebuilds it instead of
   accumulating duplicate blocks, and no component can append behind its back. The unconditional
   section comes first, then one gated block per component, each headed by a `#` title, in the
-  order those components run in `debian/main.sh`: `COMMAND_MODERN_CLI` — one gate holding the
-  dispatcher integrations in one place (`# Modern CLI tools`; `# bat`, only `compdef bat=batcat`
-  because everything else bat needs lives in `~/.config/bat/config`; `# Editor` then `# Micro`,
-  with the `EDITOR="code --wait"` branch nested one level deeper on `APP_VSCODE`; `# yazi`, the
-  existing `y()` wrapper for the binary installed inline by `modern_cli/main.sh` — `fdfind.sh` and
-  `tldr.sh` contribute nothing) — then `APP_DOCKER` (`# Docker`, the
+  order those components run in `debian/main.sh`: `COMMAND_MODERN_CLI` — one gate holding five
+  `#` sections, since everything the five `modern_cli/` sub-scripts need here lands in one place
+  (`# Modern CLI tools`; `# bat`, only `compdef bat=batcat` because everything else bat needs lives
+  in `~/.config/bat/config`; `# Editor` then `# Micro`, with the `EDITOR="code --wait"` branch
+  nested one level deeper on `APP_VSCODE`; `# yazi`, the `y()` wrapper that cd's to wherever yazi
+  was left — `fdfind.sh` and `tldr.sh` contribute nothing) — then `APP_DOCKER` (`# Docker`, the
   `lzd` alias), `APP_GIT` (`# Git`, the `lg()` wrapper) and `APP_TMUX` (`# tmux mouse scroll`).
   Block titles name the *component*, not the tool, wherever the two differ — `# Git` rather than
   `# lazygit` — matching `# Editor` / `# Micro` above them. Intra-file order is cosmetic — the
@@ -758,8 +788,10 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
     `open_command` (xdg-open). Unusable headless or over ssh.
   - `npm` — node is installed as a runtime only (the `agent-inject` plugin that
     `--app-claude-copilot-api` installs runs on node); npm is never driven by hand.
-  - `lazygit` `lazydocker` `btop` `duf`, and yazi — pure TUI or single-shot display; type the name
-    and press enter. An omz plugin would add no useful shell integration at this layer.
+  - `lazygit` `lazydocker` `btop` `duf`, and yazi's TUI half — pure TUI or single-shot display;
+    type the name, press enter. Completion buys nothing. (yazi's own `_yazi` / `_ya` are a separate
+    matter, covering the `ya` package manager and yazi's flags; `modern_cli/yazi.sh` installs them
+    from the release zip, so no plugin is needed there either.)
   - `jq` `sd` `hyperfine` `choose` `glow` — no omz plugin exists; `jsontools`' functionality is
     fully covered by jq. `choose` ships no completion upstream, and `glow` has one usage worth
     completing (`glow <file>`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,10 @@ Three independent setup trees, selected by `--setup`:
   ssh-to-remote workflow (connect, manage keys, move files) and deliberately omits `git`.
 - `debian/` — the richest tree; installs zsh + oh-my-zsh unconditionally, then a
   matrix of optional components. `--command-utils` is now a nested dispatcher:
-  `command/modern_cli/main.sh` still installs the bulk command-utility package set (including
-  tealdeer), warms the `tldr` cache, and downloads yazi / `ya` and `choose` into `/usr/local/bin`,
-  then runs `modern_cli/bat/`, `modern_cli/fdfind.sh` and `modern_cli/micro/`; each child installs
-  its own package and config and carries no flag of its own. One component is shaped unusually: `--app-git` deliberately spans all three
+  `command/modern_cli/main.sh` still installs the bulk command-utility package set and downloads
+  yazi / `ya` and `choose` into `/usr/local/bin`, then runs `modern_cli/bat/`,
+  `modern_cli/fdfind.sh`, `modern_cli/micro/` and `modern_cli/tldr.sh`; each child installs its own
+  package and config and carries no flag of its own. One component is shaped unusually: `--app-git` deliberately spans all three
   layers of a single concern instead of being split by kind: it installs the tooling (`gh` from the
   official apt repo, `git-delta`, `lazygit`), writes the global git config, owns the `gh auth login`
   block in `01-first_run.zsh`, and owns `~/.config/lazygit/config.yml`. That is why `git-delta` /
@@ -147,6 +147,16 @@ Three independent setup trees, selected by `--setup`:
   what removed `link_binaries()` from `main.sh` — `fd` was its only entry. Unlike bat it needs no
   `compdef` line, because Debian's `_fd` declares `#compdef fd` and the symlinked name is therefore
   already registered.
+
+  `modern_cli/tldr.sh` is the smallest: it installs `tealdeer` (leaving
+  `~/.config/tealdeer/config.toml` unseeded at its defaults), warms the offline page cache with
+  `tldr --update || true` (a network failure is not fatal — the cache fills on first use), and
+  symlinks Debian's `/usr/share/zsh/vendor-completions/tldr.zsh` into `$ZSH_CUSTOM/completions/`
+  under the name `_tldr` — the only reason that completion ever loads, for which see the `compinit`
+  discussion under Conventions. A symlink rather than `install -Dm 644` because the source is a
+  packaged file that apt will upgrade in place; the `[[ -f $completion ]]` guard ahead of it is
+  there because `ln -sf` against a missing source does not fail, it leaves a dangling link — the
+  exact silent-no-op failure mode the symlink exists to undo.
 - `container/` — builds and runs a Docker dev container (`dev-container`) or the
   `copilot-api` image.
 
@@ -460,17 +470,39 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   | `plugins=()`, `ZSH_THEME=`, anything `compinit` or `lib/*.zsh` reads | `.zshrc` |
   | `PATH` and anything a non-interactive shell needs | `.zshenv` (see `code/go.sh`, `code/rust.sh`) |
 
-  The `COMMAND_UTILS` runtime integration belongs in row two: its gated omz plugins provide eza,
-  fzf and zoxide integration, while `custom_env.sh` writes the `tree` alias, registers
-  `compdef bat=batcat`, configures Editor and Micro, and defines yazi's `y()` cwd-following wrapper.
-  `command/modern_cli/main.sh` owns the bulk packages and binaries and dispatches bat, fdfind and
-  Micro, but never appends shell startup files itself.
+  `compdef` is in row two rather than row four because `compinit` runs at l.127, well before
+  l.209 — `custom_env.sh`'s `COMMAND_UTILS` block writes `compdef bat=batcat` there. Two rules
+  govern that line and the symlinks around it: **`compinit` looks at a file only if its name
+  matches `_*`**, and **it registers by the name on that file's `#compdef` first line, not by the
+  file name and not by whether the command exists.** Debian's three packagers diverged along both
+  axes: `bat` ships `_batcat` declaring `#compdef batcat` (`PROJECT_EXECUTABLE=batcat`, matching
+  the binary it actually ships); `fd-find` ships `_fd` declaring `#compdef fd` though its binary is
+  `fdfind` (Debian #936036, fixed 2019, since regressed, no open bug); `tealdeer` ships a perfectly
+  valid `#compdef tldr` in a file named `tldr.zsh`, which `_*` never globs, so `_comps[tldr]` is
+  empty with no error, no clue, and no Debian bug against `src=rust-tealdeer`. Net effect: `fd`
+  catches a completion that was dangling on a name Debian never installed — free; `bat` creates a
+  name nobody registered — hence the one `compdef` line; `tldr` needs neither, because
+  `modern_cli/tldr.sh` fixes it at the source. If Debian ever fixes fd properly, add the
+  mirror-image `compdef fd=fdfind`; do **not** add it pre-emptively, since `compdef name=service`
+  on an unregistered service prints `compdef: unknown command or service: fdfind` on every start
+  (it does leave `_comps[fd]` intact).
 
-  `compinit` registers a completion by the `#compdef` declaration inside its source file. Debian's
-  `_batcat` declares `#compdef batcat`, so the new `bat` symlink needs `compdef bat=batcat` after
-  `compinit`; Debian's `_fd` already declares `#compdef fd`, so the new `fd` symlink catches that
-  completion without another line. Real symlinks win over aliases because child processes and
-  plugin probes such as `(( $+commands[fd] ))` can see them.
+  Two ways of avoiding that `compdef` line were vetted and rejected. **Doing for bat what
+  `modern_cli/tldr.sh` does for tldr cannot work** — tldr's defect is its *file name*, bat's is its
+  *content*: symlinking `_batcat` to `_bat` yields `_comps[batcat]=_bat` with `_comps[bat]` still
+  empty (verified on trixie / bat 0.25.0), and `batcat --completion zsh` prints the same
+  `#compdef batcat` because `PROJECT_EXECUTABLE` is baked in at build time. **A hand-written `_bat`
+  shim works but is the worse mechanism** — a missing `_batcat` is loud on every shell start under
+  `compdef` and a silent no-op at the first `<TAB>` under the shim, and it buys only file-placement
+  tidiness against the mechanism zsh provides for exactly this.
+
+  An alias would *not* have needed the `bat` line: zsh expands aliases into `words` before
+  completion dispatch, so `alias bat=batcat` inherits `_batcat` for free — and by the same
+  mechanism `alias fd=fdfind` **destroys** the `_fd` completion it would otherwise get. The symlink
+  wins on the other axis: an alias is shell-local state, so `(( $+commands[fd] ))` (which
+  `fzf.plugin.zsh:267` uses to pick `FZF_DEFAULT_COMMAND`) is false under it and no `$SHELL -c`
+  child — fzf's `--preview` above all — can see it, while `PATH` is exported and inherited by
+  every child.
 
   `~/.local/bin` is the one `PATH` entry the repo does *not* write itself: `command/omz.sh:44`
   uncomments omz's own template line (`export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH`,
@@ -657,15 +689,18 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   cover tarball / `go install` / conda installs that no packager touched, and they pay for it by
   running a generator on every shell start. Verified present on Debian 13 trixie: `_batcat`
   `_delta` `_dust` `_eza` `_fd` `_gh` `_procs` `_rg`. Whether a packager bothered is the only
-  variable — it does not follow from how the tool was installed.
+  variable — it does not follow from how the tool was installed. The `_` in that criterion is
+  load-bearing: tealdeer's `tldr.zsh` is in the same directory and is perfectly valid, yet never
+  loads (see the `compinit` discussion above).
   - `gh` — `dpkg -S` confirms `_gh` comes from the `gh` package itself, and `app/git/main.sh`
     installs from the official apt repo. The plugin would regenerate the same thing asynchronously
     on every start.
   - `procs` — the plugin runs `procs --gen-completion-out zsh`, which Debian's 0.14.10 rejects
     (`error: unexpected argument '--gen-completion-out' found`), and it redirects with `>|`, so
     the failed run truncates the completion file to empty. `_procs` ships with the package anyway.
-  - `bat` — no omz plugin exists, and none is wanted: `_batcat` ships with the package. The
-    symlinked `bat` command is registered with that service through `compdef bat=batcat`.
+  - `bat` — no omz plugin exists, and none is wanted: `_batcat` ships with the package. The one
+    `compdef bat=batcat` line the symlinked name needs is covered in the `compinit` discussion
+    above.
   - `bat-extras` (`eth-p/bat-extras`, a third-party suite, not sharkdp's) — **not installed at
     all**, a tool rejection rather than a plugin one. No Debian package exists, so it would mean a
     `build.sh` install path this repo has no precedent for; 1.6k★ but semi-dormant (last commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,10 @@ Three independent setup trees, selected by `--setup`:
   ssh-to-remote workflow (connect, manage keys, move files) and deliberately omits `git`.
 - `debian/` — the richest tree; installs zsh + oh-my-zsh unconditionally, then a
   matrix of optional components. `--command-utils` is now a nested dispatcher:
-  `command/modern_cli/main.sh` still installs the bulk command-utility package set (including bat,
+  `command/modern_cli/main.sh` still installs the bulk command-utility package set (including
   fd-find and tealdeer), warms the `tldr` cache, and downloads yazi / `ya` and `choose` into
-  `/usr/local/bin`, then runs `modern_cli/micro/` to install Micro and its config. The child carries
-  no flag of its own. One component is shaped unusually: `--app-git` deliberately spans all three
+  `/usr/local/bin`, then runs `modern_cli/bat/` and `modern_cli/micro/`; each child installs its own
+  package and config and carries no flag of its own. One component is shaped unusually: `--app-git` deliberately spans all three
   layers of a single concern instead of being split by kind: it installs the tooling (`gh` from the
   official apt repo, `git-delta`, `lazygit`), writes the global git config, owns the `gh auth login`
   block in `01-first_run.zsh`, and owns `~/.config/lazygit/config.yml`. That is why `git-delta` /
@@ -121,13 +121,26 @@ Three independent setup trees, selected by `--setup`:
     `~/.p10k.zsh` declaring `POWERLEVEL9K_MODE=nerdfont-v3` is the signal that the v3 font is the
     one installed.
 
-  The same general config rule applies at this layer: **a tool's own config file is a shipped
-  artifact, never an `echo` block.** `modern_cli/micro/settings.json` and `app/git/config.yml` land
-  through the same `install -Dm 644`, and `copilot_api/settings.json` is that plus `jq`
-  interpolation. What is left to `echo` is only the files this repo invented (`00-setup_env.zsh`,
-  `01-first_run.zsh`, `setup-env.plugin.zsh`) and appends into files an upstream installer or the
-  shell already made (`tmux.conf.local`, `.zshenv`, the ssh config) — plus the git config, which
-  goes through `git config --global` and has no file to ship.
+  `modern_cli/bat/` installs the `bat` package, makes the `~/.local/bin/bat` symlink over Debian's
+  `batcat`, and ships `~/.config/bat/config`. The symlinked name needs one `compdef bat=batcat`
+  line, which `custom_env.sh` writes. Its two config lines are verbatim the two options bat's own
+  `--generate-config-file` template leaves commented out, so it diffs cleanly against upstream. Its
+  format is a shell word-split per line, so — unlike micro's JSON — it takes `#` comments,
+  whole-line *or* trailing, which is what lets it carry the managed-by header; that same splitting
+  makes `--theme="TwoDark"`'s quotes decorative rather than load-bearing, the opposite of
+  `git/config.yml`'s. Where micro and lazygit silently ignore an unknown key, bat **hard-errors**
+  on one — the file's words are prepended to argv, so clap rejects it and *every* `bat` run fails
+  until it is removed. And it must be the **only** place bat's theme is set: `BAT_THEME` in the
+  environment outranks the config file. delta is unaffected either way — its theme comes from
+  gitconfig (`delta.syntax-theme`), not from `BAT_THEME`.
+
+  With `bat/config` the rule is uniform across the repo: **a tool's own config file is always a
+  shipped artifact, never an `echo` block.** `micro/settings.json`, `git/config.yml` and
+  `bat/config` land through the same `install -Dm 644`, and `copilot_api/settings.json` is that
+  plus `jq` interpolation; what is left to `echo` is only the files this repo invented
+  (`00-setup_env.zsh`, `01-first_run.zsh`, `setup-env.plugin.zsh`) and the appends into files an
+  upstream installer or the shell already made (`tmux.conf.local`, `.zshenv`, the ssh config) —
+  plus the git config, which goes through `git config --global` and has no file to ship.
 - `container/` — builds and runs a Docker dev container (`dev-container`) or the
   `copilot-api` image.
 
@@ -442,19 +455,19 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   | `PATH` and anything a non-interactive shell needs | `.zshenv` (see `code/go.sh`, `code/rust.sh`) |
 
   The `COMMAND_UTILS` runtime integration belongs in row two: its gated omz plugins provide eza,
-  fzf and zoxide integration, while `custom_env.sh` writes the `bat`, `fd` and `tree` aliases,
-  configures Editor and Micro, and defines yazi's `y()` cwd-following wrapper.
-  `command/modern_cli/main.sh` owns the bulk packages and binaries and dispatches Micro, but never
-  appends shell startup files itself. This tree deliberately uses zsh aliases for Debian's `batcat`
-  / `fdfind` names; changing those compatibility names to real executables or adding completion
-  artifacts is a separate component change.
+  fzf and zoxide integration, while `custom_env.sh` writes the `fd` and `tree` aliases, registers
+  `compdef bat=batcat`, configures Editor and Micro, and defines yazi's `y()` cwd-following wrapper.
+  `command/modern_cli/main.sh` owns the bulk packages and binaries and dispatches bat and Micro, but
+  never appends shell startup files itself. The real `~/.local/bin/bat` symlink is visible to child
+  processes; `compdef` maps that new command name to Debian's `_batcat` completion service. The fd
+  compatibility name remains a zsh alias for now.
 
   `~/.local/bin` is the one `PATH` entry the repo does *not* write itself: `command/omz.sh:44`
   uncomments omz's own template line (`export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH`,
   `.zshrc` l.2), and `omz.sh` runs first in the tree — so any later component can drop a binary
-  there and have it resolve. At this layer `tools/protobuf.sh`'s `protoc` relies on that placement
-  and therefore needs no `sudo`. Being in `.zshrc`, the entry is interactive-only; a
-  non-interactive `zsh -c` will not see it.
+  there and have it resolve. `modern_cli/bat/main.sh`'s `bat` symlink and
+  `tools/protobuf.sh`'s `protoc` both rely on that placement, and neither needs `sudo`. Being in
+  `.zshrc`, the entry is interactive-only; a non-interactive `zsh -c` will not see it.
 
   Only `PYTHON_AUTO_VRUN` is in the first row today — `python.plugin.zsh:103` decides at load
   time whether to register the `chpwd` hook, and the plugin's own README says to set it "before
@@ -519,10 +532,10 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   `main()` — the only write to that file anywhere in the tree, so a re-run rebuilds it instead of
   accumulating duplicate blocks, and no component can append behind its back. The unconditional
   section comes first, then one gated block per component, each headed by a `#` title, in the
-  order those components run in `debian/main.sh`: `COMMAND_UTILS` owns the `bat`, `fd` and `tree`
-  aliases, Editor selection and its `EDITOR="code --wait"` branch on `APP_VSCODE`, the Micro runtime
-  settings, and yazi's `y()` cwd-following wrapper; `APP_DOCKER` owns the `lzd` alias; `APP_GIT`
-  owns the `lg()` wrapper; and `APP_TMUX` owns mouse-friendly `LESS`. Block titles name the
+  order those components run in `debian/main.sh`: `COMMAND_UTILS` owns the `fd` and `tree` aliases,
+  bat's `compdef`, Editor selection and its `EDITOR="code --wait"` branch on `APP_VSCODE`, the Micro
+  runtime settings, and yazi's `y()` cwd-following wrapper; `APP_DOCKER` owns the `lzd` alias;
+  `APP_GIT` owns the `lg()` wrapper; and `APP_TMUX` owns mouse-friendly `LESS`. Block titles name the
   *component concern*, not necessarily the executable — `# Git` rather than `# lazygit`, and
   `# Editor` / `# Micro` within the command-utilities block. Intra-file order is cosmetic — the
   whole file lands at l.209, after every plugin, which is exactly what lets a value here override
@@ -639,8 +652,8 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   - `procs` — the plugin runs `procs --gen-completion-out zsh`, which Debian's 0.14.10 rejects
     (`error: unexpected argument '--gen-completion-out' found`), and it redirects with `>|`, so
     the failed run truncates the completion file to empty. `_procs` ships with the package anyway.
-  - `bat` — no omz plugin exists, and none is wanted: `_batcat` ships with the package, and this
-    tree exposes `batcat` through a zsh alias.
+  - `bat` — no omz plugin exists, and none is wanted: `_batcat` ships with the package. The
+    symlinked `bat` command is registered with that service through `compdef bat=batcat`.
   - `bat-extras` (`eth-p/bat-extras`, a third-party suite, not sharkdp's) — **not installed at
     all**, a tool rejection rather than a plugin one. No Debian package exists, so it would mean a
     `build.sh` install path this repo has no precedent for; 1.6k★ but semi-dormant (last commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,9 @@ Three independent setup trees, selected by `--setup`:
 - `debian/` — the richest tree; installs zsh + oh-my-zsh unconditionally, then a
   matrix of optional components. `--command-utils` is now a nested dispatcher:
   `command/modern_cli/main.sh` still installs the bulk command-utility package set (including
-  fd-find and tealdeer), warms the `tldr` cache, and downloads yazi / `ya` and `choose` into
-  `/usr/local/bin`, then runs `modern_cli/bat/` and `modern_cli/micro/`; each child installs its own
-  package and config and carries no flag of its own. One component is shaped unusually: `--app-git` deliberately spans all three
+  tealdeer), warms the `tldr` cache, and downloads yazi / `ya` and `choose` into `/usr/local/bin`,
+  then runs `modern_cli/bat/`, `modern_cli/fdfind.sh` and `modern_cli/micro/`; each child installs
+  its own package and config and carries no flag of its own. One component is shaped unusually: `--app-git` deliberately spans all three
   layers of a single concern instead of being split by kind: it installs the tooling (`gh` from the
   official apt repo, `git-delta`, `lazygit`), writes the global git config, owns the `gh auth login`
   block in `01-first_run.zsh`, and owns `~/.config/lazygit/config.yml`. That is why `git-delta` /
@@ -141,6 +141,12 @@ Three independent setup trees, selected by `--setup`:
   (`00-setup_env.zsh`, `01-first_run.zsh`, `setup-env.plugin.zsh`) and the appends into files an
   upstream installer or the shell already made (`tmux.conf.local`, `.zshenv`, the ssh config) —
   plus the git config, which goes through `git config --global` and has no file to ship.
+
+  `modern_cli/fdfind.sh` is that same arrangement for `fd` minus the config file: it installs
+  `fd-find` and makes the `~/.local/bin/fd` symlink over Debian's `fdfind`, and extracting it is
+  what removed `link_binaries()` from `main.sh` — `fd` was its only entry. Unlike bat it needs no
+  `compdef` line, because Debian's `_fd` declares `#compdef fd` and the symlinked name is therefore
+  already registered.
 - `container/` — builds and runs a Docker dev container (`dev-container`) or the
   `copilot-api` image.
 
@@ -455,19 +461,25 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   | `PATH` and anything a non-interactive shell needs | `.zshenv` (see `code/go.sh`, `code/rust.sh`) |
 
   The `COMMAND_UTILS` runtime integration belongs in row two: its gated omz plugins provide eza,
-  fzf and zoxide integration, while `custom_env.sh` writes the `fd` and `tree` aliases, registers
+  fzf and zoxide integration, while `custom_env.sh` writes the `tree` alias, registers
   `compdef bat=batcat`, configures Editor and Micro, and defines yazi's `y()` cwd-following wrapper.
-  `command/modern_cli/main.sh` owns the bulk packages and binaries and dispatches bat and Micro, but
-  never appends shell startup files itself. The real `~/.local/bin/bat` symlink is visible to child
-  processes; `compdef` maps that new command name to Debian's `_batcat` completion service. The fd
-  compatibility name remains a zsh alias for now.
+  `command/modern_cli/main.sh` owns the bulk packages and binaries and dispatches bat, fdfind and
+  Micro, but never appends shell startup files itself.
+
+  `compinit` registers a completion by the `#compdef` declaration inside its source file. Debian's
+  `_batcat` declares `#compdef batcat`, so the new `bat` symlink needs `compdef bat=batcat` after
+  `compinit`; Debian's `_fd` already declares `#compdef fd`, so the new `fd` symlink catches that
+  completion without another line. Real symlinks win over aliases because child processes and
+  plugin probes such as `(( $+commands[fd] ))` can see them.
 
   `~/.local/bin` is the one `PATH` entry the repo does *not* write itself: `command/omz.sh:44`
   uncomments omz's own template line (`export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH`,
   `.zshrc` l.2), and `omz.sh` runs first in the tree — so any later component can drop a binary
-  there and have it resolve. `modern_cli/bat/main.sh`'s `bat` symlink and
-  `tools/protobuf.sh`'s `protoc` both rely on that placement, and neither needs `sudo`. Being in
-  `.zshrc`, the entry is interactive-only; a non-interactive `zsh -c` will not see it.
+  there and have it resolve. `modern_cli/fdfind.sh`'s `fd` symlink,
+  `modern_cli/bat/main.sh`'s `bat` symlink and `tools/protobuf.sh`'s `protoc` all rely on that
+  placement, and none needs `sudo`. Being in `.zshrc`, the entry is interactive-only — enough for
+  the `(( $+commands[fd] ))` probes plugins do while `.zshrc` is still being sourced, but a
+  non-interactive `zsh -c` will not see it.
 
   Only `PYTHON_AUTO_VRUN` is in the first row today — `python.plugin.zsh:103` decides at load
   time whether to register the `chpwd` hook, and the plugin's own README says to set it "before
@@ -532,8 +544,8 @@ dependency — there is no standalone `--tools-node` component or `debian/tools/
   `main()` — the only write to that file anywhere in the tree, so a re-run rebuilds it instead of
   accumulating duplicate blocks, and no component can append behind its back. The unconditional
   section comes first, then one gated block per component, each headed by a `#` title, in the
-  order those components run in `debian/main.sh`: `COMMAND_UTILS` owns the `fd` and `tree` aliases,
-  bat's `compdef`, Editor selection and its `EDITOR="code --wait"` branch on `APP_VSCODE`, the Micro
+  order those components run in `debian/main.sh`: `COMMAND_UTILS` owns the `tree` alias, bat's
+  `compdef`, Editor selection and its `EDITOR="code --wait"` branch on `APP_VSCODE`, the Micro
   runtime settings, and yazi's `y()` cwd-following wrapper; `APP_DOCKER` owns the `lzd` alias;
   `APP_GIT` owns the `lg()` wrapper; and `APP_TMUX` owns mouse-friendly `LESS`. Block titles name the
   *component concern*, not necessarily the executable — `# Git` rather than `# lazygit`, and

--- a/README.md
+++ b/README.md
@@ -30,25 +30,25 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
         [--flag]
 ```
 
-| main args          | script args                             |
-| ------------------ | --------------------------------------- |
-| `--command-utils`  |                                         |
-| `--code-bash`      |                                         |
-| `--code-go`        |                                         |
-| `--code-python`    |                                         |
-| `--code-rust`      |                                         |
-| `--tools-protobuf` |                                         |
-| `--app-claude`     | `--app-claude-copilot-api`              |
-|                    | `--app-claude-base-url <v>`             |
-|                    | `--app-claude-auth-token <v>`           |
-|                    | `--app-claude-default-opus-model <v>`   |
-|                    | `--app-claude-default-sonnet-model <v>` |
-|                    | `--app-claude-default-haiku-model <v>`  |
-| `--app-docker`     |                                         |
-| `--app-git`        | `--app-git-user-name <v>`               |
-|                    | `--app-git-user-email <v>`              |
-| `--app-tmux`       |                                         |
-| `--app-vscode`     |                                         |
+| main args              | script args                             |
+| ---------------------- | --------------------------------------- |
+| `--command-modern-cli` |                                         |
+| `--code-bash`          |                                         |
+| `--code-go`            |                                         |
+| `--code-python`        |                                         |
+| `--code-rust`          |                                         |
+| `--tools-protobuf`     |                                         |
+| `--app-claude`         | `--app-claude-copilot-api`              |
+|                        | `--app-claude-base-url <v>`             |
+|                        | `--app-claude-auth-token <v>`           |
+|                        | `--app-claude-default-opus-model <v>`   |
+|                        | `--app-claude-default-sonnet-model <v>` |
+|                        | `--app-claude-default-haiku-model <v>`  |
+| `--app-docker`         |                                         |
+| `--app-git`            | `--app-git-user-name <v>`               |
+|                        | `--app-git-user-email <v>`              |
+| `--app-tmux`           |                                         |
+| `--app-vscode`         |                                         |
 
 ```bash
 xargs -L1 code --install-extension < debian/vscode/extensions.txt

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ curl -fsSL https://raw.githubusercontent.com/acathe/setup-env/master/main.sh \
 | `--app-docker`     |                                         |
 | `--app-git`        | `--app-git-user-name <v>`               |
 |                    | `--app-git-user-email <v>`              |
-| `--app-micro`      |                                         |
 | `--app-tmux`       |                                         |
 | `--app-vscode`     |                                         |
 

--- a/debian/app/tmux.sh
+++ b/debian/app/tmux.sh
@@ -2,8 +2,6 @@
 
 set -euo pipefail
 
-COMMAND_UTILS="${COMMAND_UTILS:-0}"
-
 APP_CLAUDE="${APP_CLAUDE:-0}"
 
 install_oh_my_tmux() {
@@ -13,11 +11,6 @@ install_oh_my_tmux() {
     install_sh="$(mktemp)"
     curl -fsSL 'https://raw.githubusercontent.com/gpakosz/.tmux/master/install.sh' -o "$install_sh"
     bash "$install_sh" < /dev/null
-}
-
-install_sesh() {
-    curl -fsSL 'https://github.com/joshmedeski/sesh/releases/latest/download/sesh_Linux_x86_64.tar.gz' \
-        | sudo tar -xzf - -C '/usr/local/bin' sesh
 }
 
 configure_tmux() {
@@ -42,13 +35,6 @@ configure_tmux() {
         echo '    }'
         echo '}'
 
-        if [[ $COMMAND_UTILS == '1' ]]; then
-            echo ''
-            echo '# Sesh'
-            echo 'set -g detach-on-destroy off'
-            echo 'bind-key T display-popup -w 80% -h 70% -E "sesh picker"'
-        fi
-
         if [[ $APP_CLAUDE == '1' ]]; then
             echo ''
             echo '# Claude Code'
@@ -64,11 +50,6 @@ main() {
     sudo apt-get install -y tmux
 
     install_oh_my_tmux
-
-    if [[ $COMMAND_UTILS == '1' ]]; then
-        install_sesh
-    fi
-
     configure_tmux
 }
 

--- a/debian/command/modern_cli/bat/config
+++ b/debian/command/modern_cli/bat/config
@@ -1,0 +1,2 @@
+--theme="TwoDark"
+--italic-text=always

--- a/debian/command/modern_cli/bat/main.sh
+++ b/debian/command/modern_cli/bat/main.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() {
+    sudo apt-get update
+    sudo apt-get install -y bat
+
+    mkdir -p "$HOME/.local/bin"
+    ln -sf "$(command -v batcat)" "$HOME/.local/bin/bat"
+
+    install -Dm 644 './config' "$HOME/.config/bat/config"
+
+}
+
+if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    main "$@"
+fi

--- a/debian/command/modern_cli/fdfind.sh
+++ b/debian/command/modern_cli/fdfind.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() {
+    sudo apt-get update
+    sudo apt-get install -y fd-find
+
+    mkdir -p "$HOME/.local/bin"
+    ln -sf "$(command -v fdfind)" "$HOME/.local/bin/fd"
+}
+
+if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    main "$@"
+fi

--- a/debian/command/modern_cli/main.sh
+++ b/debian/command/modern_cli/main.sh
@@ -27,7 +27,6 @@ main() {
         ripgrep \
         zoxide \
         fzf \
-        tealdeer \
         hyperfine \
         sd \
         btop \
@@ -35,13 +34,12 @@ main() {
         duf \
         procs
 
-    tldr --update || true
-
     install_binaries
 
     bash './bat/main.sh' "$@"
     bash './fdfind.sh' "$@"
     bash './micro/main.sh' "$@"
+    bash './tldr.sh' "$@"
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then

--- a/debian/command/modern_cli/main.sh
+++ b/debian/command/modern_cli/main.sh
@@ -24,12 +24,6 @@ install_binaries() {
     local tmp
     tmp="$(mktemp -d)"
 
-    curl -fsSL -o "$tmp/yazi.zip" \
-        'https://github.com/sxyazi/yazi/releases/latest/download/yazi-x86_64-unknown-linux-gnu.zip'
-    unzip -q "$tmp/yazi.zip" -d "$tmp"
-    sudo install -m 755 "$tmp/yazi-x86_64-unknown-linux-gnu/yazi" '/usr/local/bin/yazi'
-    sudo install -m 755 "$tmp/yazi-x86_64-unknown-linux-gnu/ya" '/usr/local/bin/ya'
-
     curl -fsSL -o "$tmp/choose" \
         'https://github.com/theryangeary/choose/releases/latest/download/choose-x86_64-unknown-linux-gnu'
     sudo install -m 755 "$tmp/choose" '/usr/local/bin/choose'
@@ -43,6 +37,7 @@ main() {
     bash './fdfind.sh' "$@"
     bash './micro/main.sh' "$@"
     bash './tldr.sh' "$@"
+    bash './yazi.sh' "$@"
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then

--- a/debian/command/modern_cli/main.sh
+++ b/debian/command/modern_cli/main.sh
@@ -24,7 +24,6 @@ main() {
         unzip \
         glow \
         eza \
-        fd-find \
         ripgrep \
         zoxide \
         fzf \
@@ -41,6 +40,7 @@ main() {
     install_binaries
 
     bash './bat/main.sh' "$@"
+    bash './fdfind.sh' "$@"
     bash './micro/main.sh' "$@"
 }
 

--- a/debian/command/modern_cli/main.sh
+++ b/debian/command/modern_cli/main.sh
@@ -2,6 +2,24 @@
 
 set -euo pipefail
 
+install_packages() {
+    sudo apt-get update
+    sudo apt-get install -y \
+        jq \
+        unzip \
+        glow \
+        eza \
+        ripgrep \
+        zoxide \
+        fzf \
+        hyperfine \
+        sd \
+        btop \
+        du-dust \
+        duf \
+        procs
+}
+
 install_binaries() {
     local tmp
     tmp="$(mktemp -d)"
@@ -18,22 +36,7 @@ install_binaries() {
 }
 
 main() {
-    sudo apt-get update
-    sudo apt-get install -y \
-        jq \
-        unzip \
-        glow \
-        eza \
-        ripgrep \
-        zoxide \
-        fzf \
-        hyperfine \
-        sd \
-        btop \
-        du-dust \
-        duf \
-        procs
-
+    install_packages
     install_binaries
 
     bash './bat/main.sh' "$@"

--- a/debian/command/modern_cli/main.sh
+++ b/debian/command/modern_cli/main.sh
@@ -24,7 +24,6 @@ main() {
         unzip \
         glow \
         eza \
-        bat \
         fd-find \
         ripgrep \
         zoxide \
@@ -41,6 +40,7 @@ main() {
 
     install_binaries
 
+    bash './bat/main.sh' "$@"
     bash './micro/main.sh' "$@"
 }
 

--- a/debian/command/modern_cli/main.sh
+++ b/debian/command/modern_cli/main.sh
@@ -40,6 +40,8 @@ main() {
     tldr --update || true
 
     install_binaries
+
+    bash './micro/main.sh' "$@"
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then

--- a/debian/command/modern_cli/micro/main.sh
+++ b/debian/command/modern_cli/micro/main.sh
@@ -9,8 +9,7 @@ main() {
     micro -plugin install detectindent
     micro -plugin install filemanager
 
-    mkdir -p "$HOME/.config/micro"
-    cp './settings.json' "$HOME/.config/micro/settings.json"
+    install -Dm 644 './settings.json' "$HOME/.config/micro/settings.json"
 }
 
 if [[ $0 == "${BASH_SOURCE[0]}" ]]; then

--- a/debian/command/modern_cli/micro/settings.json
+++ b/debian/command/modern_cli/micro/settings.json
@@ -9,7 +9,5 @@
   "rmtrailingws": true,
   "savecursor": true,
   "saveundo": true,
-  "scrollbar": true,
-  "showchars": "tab=»,itab=»",
-  "truecolor": true
+  "scrollbar": true
 }

--- a/debian/command/modern_cli/tldr.sh
+++ b/debian/command/modern_cli/tldr.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+
+set_completion() {
+    local completion='/usr/share/zsh/vendor-completions/tldr.zsh'
+    if [[ ! -f $completion ]]; then
+        echo "$completion does not exist." >&2
+        return 1
+    fi
+
+    mkdir -p "$ZSH_CUSTOM/completions"
+    ln -sf "$completion" "$ZSH_CUSTOM/completions/_tldr"
+}
+
+main() {
+    sudo apt-get update
+    sudo apt-get install -y tealdeer
+
+    tldr --update || true # 预热 tealdeer 离线缓存，网络失败不致命
+    set_completion
+}
+
+if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    main "$@"
+fi

--- a/debian/command/modern_cli/yazi.sh
+++ b/debian/command/modern_cli/yazi.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+
+fetch_yazi() {
+    local tmp
+    tmp="$(mktemp -d)"
+
+    curl -fsSL -o "$tmp/yazi.zip" \
+        'https://github.com/sxyazi/yazi/releases/latest/download/yazi-x86_64-unknown-linux-gnu.zip'
+    unzip -q "$tmp/yazi.zip" -d "$tmp"
+
+    echo "$tmp/yazi-x86_64-unknown-linux-gnu"
+}
+
+install_yazi() {
+    local dir="$1"
+
+    install -Dm 755 "$dir/yazi" "$HOME/.local/bin/yazi"
+    install -Dm 755 "$dir/ya" "$HOME/.local/bin/ya"
+}
+
+set_completion() {
+    local dir="$1"
+
+    install -Dm 644 "$dir/completions/_yazi" "$ZSH_CUSTOM/completions/_yazi"
+    install -Dm 644 "$dir/completions/_ya" "$ZSH_CUSTOM/completions/_ya"
+}
+
+main() {
+    sudo apt-get update
+    sudo apt-get install -y file unzip
+
+    local dir
+    dir="$(fetch_yazi)"
+
+    install_yazi "$dir"
+    set_completion "$dir"
+}
+
+if [[ $0 == "${BASH_SOURCE[0]}" ]]; then
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    main "$@"
+fi

--- a/debian/command/omz_custom/custom_env.sh
+++ b/debian/command/omz_custom/custom_env.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-COMMAND_UTILS="${COMMAND_UTILS:-0}"
+COMMAND_MODERN_CLI="${COMMAND_MODERN_CLI:-0}"
 
 APP_DOCKER="${APP_DOCKER:-0}"
 APP_GIT="${APP_GIT:-0}"
@@ -27,9 +27,10 @@ render_blocks() {
     echo 'ZSHZ_CASE=smart'
     echo 'ZSHZ_TILDE=1'
 
-    if [[ $COMMAND_UTILS == '1' ]]; then
+    if [[ $COMMAND_MODERN_CLI == '1' ]]; then
         echo
-        echo '# Command utilities'
+        echo '# Modern CLI tools'
+        # eza 插件不提供 tree 别名，手写补上（ls/ll/la 等由插件承担）
         echo 'alias tree="eza --tree"'
         echo
         echo '# bat'

--- a/debian/command/omz_custom/custom_env.sh
+++ b/debian/command/omz_custom/custom_env.sh
@@ -30,7 +30,6 @@ render_blocks() {
     if [[ $COMMAND_UTILS == '1' ]]; then
         echo
         echo '# Command utilities'
-        echo 'alias fd="fdfind"'
         echo 'alias tree="eza --tree"'
         echo
         echo '# bat'

--- a/debian/command/omz_custom/custom_env.sh
+++ b/debian/command/omz_custom/custom_env.sh
@@ -30,9 +30,11 @@ render_blocks() {
     if [[ $COMMAND_UTILS == '1' ]]; then
         echo
         echo '# Command utilities'
-        echo 'alias bat="batcat"'
         echo 'alias fd="fdfind"'
         echo 'alias tree="eza --tree"'
+        echo
+        echo '# bat'
+        echo 'compdef bat=batcat'
         echo
         echo '# Editor'
         echo 'export EDITOR=micro'

--- a/debian/command/omz_custom/custom_env.sh
+++ b/debian/command/omz_custom/custom_env.sh
@@ -6,7 +6,6 @@ COMMAND_UTILS="${COMMAND_UTILS:-0}"
 
 APP_DOCKER="${APP_DOCKER:-0}"
 APP_GIT="${APP_GIT:-0}"
-APP_MICRO="${APP_MICRO:-0}"
 APP_TMUX="${APP_TMUX:-0}"
 APP_VSCODE="${APP_VSCODE:-0}"
 
@@ -34,11 +33,19 @@ render_blocks() {
         echo 'alias bat="batcat"'
         echo 'alias fd="fdfind"'
         echo 'alias tree="eza --tree"'
-        if [[ $APP_MICRO == '1' ]]; then
-            echo
-            echo '# Micro'
-            echo 'alias micror="micro -readonly true"'
+        echo
+        echo '# Editor'
+        echo 'export EDITOR=micro'
+        if [[ $APP_VSCODE == '1' ]]; then
+            echo 'if [[ "$TERM_PROGRAM" == "vscode" ]]; then'
+            echo '  export EDITOR="code --wait"'
+            echo 'fi'
         fi
+        echo 'export VISUAL="$EDITOR"'
+        echo
+        echo '# Micro'
+        echo 'export MICRO_TRUECOLOR=1'
+        echo 'alias micror="micro -readonly true"'
         echo
         echo '# yazi'
         echo 'function y() {'
@@ -67,18 +74,6 @@ render_blocks() {
         echo '        rm -f $LAZYGIT_NEW_DIR_FILE > /dev/null'
         echo '    fi'
         echo '}'
-    fi
-
-    if [[ $APP_MICRO == '1' ]]; then
-        echo
-        echo '# Editor'
-        echo 'export EDITOR=micro'
-        if [[ $APP_VSCODE == '1' ]]; then
-            echo 'if [[ "$TERM_PROGRAM" == "vscode" ]]; then'
-            echo '  export EDITOR="code --wait"'
-            echo 'fi'
-        fi
-        echo 'export VISUAL="$EDITOR"'
     fi
 
     if [[ $APP_TMUX == '1' ]]; then

--- a/debian/command/omz_custom/main.sh
+++ b/debian/command/omz_custom/main.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-COMMAND_UTILS="${COMMAND_UTILS:-0}"
+COMMAND_MODERN_CLI="${COMMAND_MODERN_CLI:-0}"
 
 APP_DOCKER="${APP_DOCKER:-0}"
 APP_GIT="${APP_GIT:-0}"
@@ -46,9 +46,9 @@ install_plugin() {
     append_plugin 'universalarchive'
     append_plugin 'z'
 
-    [[ $COMMAND_UTILS == '1' ]] && append_plugin 'eza'
-    [[ $COMMAND_UTILS == '1' ]] && append_plugin 'fzf'
-    [[ $COMMAND_UTILS == '1' ]] && append_plugin 'zoxide'
+    [[ $COMMAND_MODERN_CLI == '1' ]] && append_plugin 'eza'
+    [[ $COMMAND_MODERN_CLI == '1' ]] && append_plugin 'fzf'
+    [[ $COMMAND_MODERN_CLI == '1' ]] && append_plugin 'zoxide'
 
     [[ $APP_DOCKER == '1' ]] && append_plugin 'docker'
     [[ $APP_DOCKER == '1' ]] && append_plugin 'docker-compose'
@@ -66,7 +66,7 @@ install_plugin() {
     append_plugin 'zsh-autosuggestions'
     append_plugin 'zsh-syntax-highlighting'
 
-    [[ $COMMAND_UTILS == '1' ]] && append_plugin 'fzf-tab'
+    [[ $COMMAND_MODERN_CLI == '1' ]] && append_plugin 'fzf-tab'
 
     return 0
 }

--- a/debian/main.sh
+++ b/debian/main.sh
@@ -14,7 +14,6 @@ export TOOLS_PROTOBUF="${TOOLS_PROTOBUF:-0}"
 export APP_CLAUDE="${APP_CLAUDE:-0}"
 export APP_DOCKER="${APP_DOCKER:-0}"
 export APP_GIT="${APP_GIT:-0}"
-export APP_MICRO="${APP_MICRO:-0}"
 export APP_TMUX="${APP_TMUX:-0}"
 export APP_VSCODE="${APP_VSCODE:-0}"
 
@@ -58,10 +57,6 @@ parse_args() {
                 APP_GIT=1
                 shift
                 ;;
-            --app-micro)
-                APP_MICRO=1
-                shift
-                ;;
             --app-tmux)
                 APP_TMUX=1
                 shift
@@ -83,7 +78,7 @@ main() {
     bash './command/omz_custom/main.sh' "$@"
 
     if [[ $COMMAND_UTILS == '1' ]]; then
-        bash './command/utils.sh' "$@"
+        bash './command/modern_cli/main.sh' "$@"
     fi
 
     if [[ $CODE_BASH == '1' ]]; then
@@ -116,10 +111,6 @@ main() {
 
     if [[ $APP_GIT == '1' ]]; then
         bash './app/git/main.sh' "$@"
-    fi
-
-    if [[ $APP_MICRO == '1' ]]; then
-        bash './app/micro/main.sh' "$@"
     fi
 
     if [[ $APP_TMUX == '1' ]]; then

--- a/debian/main.sh
+++ b/debian/main.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export COMMAND_UTILS="${COMMAND_UTILS:-0}"
+export COMMAND_MODERN_CLI="${COMMAND_MODERN_CLI:-0}"
 
 export CODE_BASH="${CODE_BASH:-0}"
 export CODE_GO="${CODE_GO:-0}"
@@ -21,8 +21,8 @@ parse_args() {
     POSITIONAL=()
     while (($# > 0)); do
         case "$1" in
-            --command-utils)
-                COMMAND_UTILS=1
+            --command-modern-cli)
+                COMMAND_MODERN_CLI=1
                 shift
                 ;;
             --code-bash)
@@ -77,7 +77,7 @@ main() {
     bash './command/omz.sh' "$@"
     bash './command/omz_custom/main.sh' "$@"
 
-    if [[ $COMMAND_UTILS == '1' ]]; then
+    if [[ $COMMAND_MODERN_CLI == '1' ]]; then
         bash './command/modern_cli/main.sh' "$@"
     fi
 

--- a/debian/todo.md
+++ b/debian/todo.md
@@ -1,0 +1,339 @@
+# Debian TODO
+
+只记 debian 树尚未落地的事项。已定论的结论与**已否决**清单（不加的插件、不做补全的工具）都在
+`CLAUDE.md`，条目一旦落地就从这里移走。
+
+调研基准：`~/.oh-my-zsh` @ `b37dd49`（2026-07-23），系统 Debian 13 trixie。
+
+## 总览
+
+- [ ] 1 修 `--command-modern-cli` 下的三处插件顺序回退
+- [ ] 2 `z` 与 `zoxide` 互斥
+- [ ] 3 eza 的 zstyle 落 `setup-env` 插件
+- [ ] 4 fzf / fzf-tab / magic-enter 的配置落 `00-setup_env.zsh`
+- [ ] 5 atuin 的 zsh 补全落 fpath
+- [ ] 6 引入 atuin 接管 `^R` 与 `↑`
+- [ ] 7 CLAUDE.md 同步（随 1–4 落地）
+
+1–6 里 1–4 只动 `command/omz_custom/`，5–6 只动 `command/modern_cli/main.sh`，互不冲突，且全部
+gate 在 `--command-modern-cli`，默认安装路径不受影响。7 是随 1–4 一起改的文档债。
+
+### Modern CLI 工具配置
+
+- [ ] `jq`
+- [ ] `unzip`
+- [x] `glow`
+- [ ] `eza`
+- [ ] `ripgrep`
+- [ ] `zoxide`
+- [ ] `fzf`
+- [ ] `hyperfine`
+- [ ] `sd`
+- [ ] `btop`
+- [ ] `dust`
+- [ ] `duf`
+- [ ] `procs`
+- [ ] `choose`
+- [x] `bat`
+- [x] `fd`
+- [x] `micro`
+- [x] `tldr`
+
+---
+
+## 1 · `--command-modern-cli` 下的三处插件顺序回退
+
+**文件**：`debian/command/omz_custom/main.sh` 的 `install_plugin()`
+
+**现状** `fzf` 混在中段的 `COMMAND_MODERN_CLI` 那批里（`:50`），`fzf-tab` 追加在函数最末
+（`:69`）—— 即 `zsh-autosuggestions` / `zsh-syntax-highlighting` 之后。`append_plugin()` 是纯尾部
+追加，数组顺序就是调用顺序，所以这三条同时违反 `CLAUDE.md`「omz plugin ordering」的：
+
+| # | 违反 | 上游依据 |
+| --- | --- | --- |
+| 1 | `zsh-syntax-highlighting` 不是最后一个 | 上游 INSTALL.md 硬要求 |
+| 2 | `fzf-tab` 落在包装 ZLE widget 的插件之后 | fzf-tab README 第 2 条 |
+| 3 | `fzf` 在 `fzf-tab` 之前 | fzf 的 `completion.zsh` 把当时的 `^I` 绑定存为 `fzf_default_completion`，作非 `**` 触发时的回退 |
+
+第 3 条反了的后果不是「不生效」而是**套娃**：fzf-tab 成为最外层 widget，它调用 orig widget 取
+补全列表时会真的运行交互式的 `fzf-completion`，弹出两层 fzf。
+
+**改法** 从中段 gate 块删掉 `append_plugin 'fzf'`（`eza` / `zoxide` 留原位 —— omz 内置、纯别名、
+不碰 ZLE，位置自由），尾部改成：
+
+```bash
+    append_plugin 'ohmyzsh-full-autoupdate'
+    append_plugin 'you-should-use'
+    [[ $COMMAND_MODERN_CLI == '1' ]] && append_plugin 'fzf-tab'
+    [[ $COMMAND_MODERN_CLI == '1' ]] && append_plugin 'fzf'
+    append_plugin 'zsh-autosuggestions'
+    append_plugin 'zsh-syntax-highlighting' # 上游要求最后
+
+    return 0
+```
+
+同时满足约束 4：四个 clone 插件全部排在 `ohmyzsh-full-autoupdate` 之后。末条虽已是无条件语句，
+`return 0` 仍保留 —— 理由见 `CLAUDE.md` 的 `set -e` 一节，靠「最后一行碰巧无条件」会被下一次编辑
+悄悄弄坏。
+
+**全 flag 开启后的目标数组**：
+
+```zsh
+plugins=(setup-env aliases colored-man-pages dirhistory extract fancy-ctrl-z magic-enter safe-paste
+         sudo universalarchive eza zoxide docker docker-compose git tmux vscode golang python uv
+         rust ohmyzsh-full-autoupdate you-should-use fzf-tab fzf zsh-autosuggestions
+         zsh-syntax-highlighting)
+```
+
+（实际是一行；`z` 已被第 2 节移除。中段工具插件的相对顺序无约束。）
+
+---
+
+## 2 · `z` 与 `zoxide` 互斥
+
+**文件**：`main.sh` 的 `install_plugin()`、`custom_env.sh` 的 `render_blocks()`
+
+**现状** `main.sh:47` 无条件 `append_plugin 'z'`，`custom_env.sh` 的 `# z` 块（`ZSHZ_CASE` /
+`ZSHZ_TILDE`）同样无条件。而 `zoxide` 插件跑的是 `zoxide init --cmd z`，开
+`--command-modern-cli` 时它接管同一个命令名，zsh-z 的 1108 行代码和它的 `chpwd` / `precmd` hook
+纯属白跑。
+
+**改法** 两处一起条件化：
+
+```bash
+[[ $COMMAND_MODERN_CLI != '1' ]] && append_plugin 'z'
+```
+
+`custom_env.sh` 里把 `# z` 整块（含前导空行）包进 `if [[ $COMMAND_MODERN_CLI != '1' ]]; then … fi`
+—— 用 `if` 不用 `[[ ]] &&`，理由见 `CLAUDE.md` 的 `set -e` 一节。
+
+**不影响两树一致性**：`CLAUDE.md` 要求「debian 全 flag 关闭时两边生成的 `00-setup_env.zsh` 应
+`cmp` 相等」。`COMMAND_MODERN_CLI` 默认为 0，`# z` 块照常输出，该不变式仍成立。只是 debian 的
+「无条件段」从此有一条是反向 gate 的，需要在 `CLAUDE.md` 补一句（见第 7 节）。
+
+---
+
+## 3 · eza 的 zstyle → `setup-env` 插件
+
+**文件**：`pre_plugin.sh` 的 `render_blocks()`
+
+**现状** 只有 `CODE_PYTHON` 一块，eza 一条 zstyle 也没设，`ll` 只是裸 `eza -l`。
+
+**改法** 照现有 `CODE_PYTHON` 段的写法加一个 gate 块：
+
+```bash
+        if [[ $COMMAND_MODERN_CLI == '1' ]]; then
+            echo '# eza'
+            echo 'zstyle ":omz:plugins:eza" "dirs-first" yes'
+            echo 'zstyle ":omz:plugins:eza" "git-status" yes'
+            echo 'zstyle ":omz:plugins:eza" "header" yes'
+            echo 'zstyle ":omz:plugins:eza" "icons" yes'
+            echo 'zstyle ":omz:plugins:eza" "time-style" "relative"'
+        fi
+```
+
+**为什么是 `setup-env` 而不是 `00-setup_env.zsh`** `eza.plugin.zsh` 顶层直接调 `_configure_eza`，
+zstyle 在**加载期**就被读走拼成 `_EZA_HEAD` / `_EZA_TAIL` 再生成别名；`00-setup_env.zsh` 在
+`oh-my-zsh.sh` l.209 加载，晚于 l.203 的插件循环，写那里就晚了。这正是 `setup-env` 插件
+（`plugins=()` 首位）存在的理由。
+
+**生成侧引号** 按约定「`echo` 单引号、内容双引号」写。zsh 在这里对 `"…"` 与 `'…'` 等价（内容
+无可展开成分），所以不必把外层翻成双引号，也就用不上 `'\''`。
+
+**备注** `git-status` 会让大仓库里的 `ll` 变慢，`icons` 需要 Nerd Font —— 两条都可按需去掉。
+
+---
+
+## 4 · fzf / fzf-tab / magic-enter 的配置 → `00-setup_env.zsh`
+
+**文件**：`custom_env.sh` 已有的 `COMMAND_MODERN_CLI`（`# Modern CLI tools`）块
+
+三者的变量都是**运行期**读，落 `00-setup_env.zsh`（l.209，在全部插件之后）正合适 —— 这也正是
+这个文件能覆盖插件已设值的原因。追加在现有 `compdef bat=batcat` / `alias tree` / `function y()`
+之后即可，不新开 gate 块。
+
+```zsh
+# ── fzf ──
+# 软链之后 $+commands[fd] 为真，插件会自行设 FZF_DEFAULT_COMMAND；这里显式覆盖以补上 --follow，
+# 并补齐插件不设的两项 —— fzf 0.60 的 ^T / Alt-C 默认走内置 walker，它不读 .gitignore
+export FZF_DEFAULT_COMMAND="fd --type f --hidden --follow --exclude .git"
+export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
+export FZF_ALT_C_COMMAND="fd --type d --hidden --follow --exclude .git"
+export FZF_DEFAULT_OPTS="--height 40% --layout=reverse --border --info=inline --cycle"
+export FZF_CTRL_T_OPTS="--preview \"bat --color=always --style=numbers --line-range=:200 {}\" --preview-window=right,60%,wrap"
+export FZF_ALT_C_OPTS="--preview \"eza --tree --level=2 --color=always --icons {}\""
+
+# ── fzf-tab ──
+zstyle ":completion:*:*:*:*:*" menu no
+zstyle ":completion:*:descriptions" format "[%d]"
+zstyle ":completion:*" list-colors ${(s.:.)LS_COLORS}
+zstyle ":completion:*:git-checkout:*" sort false
+zstyle ":fzf-tab:complete:cd:*" fzf-preview "eza -1 --color=always --icons $realpath"
+zstyle ":fzf-tab:*" switch-group "<" ">"
+zstyle ":fzf-tab:*" fzf-flags --height=40% --layout=reverse --border --cycle
+
+# ── magic-enter ──
+MAGIC_ENTER_OTHER_COMMAND="eza -lah --git --icons"
+```
+
+五个要点：
+
+- **`FZF_CTRL_T_OPTS` 里的 `bat` 不需要再 gate 一层**。bat 与 fzf 同属 `--command-modern-cli`，
+  开了这个 flag 就一定有 `bat`，不存在跨 flag 依赖。
+- **`menu no` 必须写成五级 pattern**。zstyle 按 pattern 具体度决胜，omz `lib/completion.zsh:14`
+  设的是五级的 `zstyle ':completion:*:*:*:*:*' menu select`，比 fzf-tab README 里单级的
+  `':completion:*'` 更具体，照抄 README 无效。fzf-tab 靠它才拿得到 unambiguous prefix。
+- **`list-colors` 是覆盖不是新增**。`lib/completion.zsh:31` 把它设成了空串。
+- **`FZF_DEFAULT_COMMAND` 的覆盖成立**。`fzf.plugin.zsh:266` 的赋值有 `[[ -z … ]]` 守卫且发生在
+  l.203，我们在 l.209 重设，晚者胜。
+- **`MAGIC_ENTER_OTHER_COMMAND` 是修语义错配，不是审美偏好**。默认值 `ls -lh .` 装了 eza 后经
+  别名变成 `eza -g -l -h .`，而 eza 的 `-h` 是 `--header` 不是 human-readable。不装 eza 时默认值
+  没问题，装了才需要改。插件在 `:4` 用 `: ${VAR:="ls -lh ."}` 设默认，widget 在 `:19` 于运行期读
+  该变量 —— 我们在 l.209 的赋值晚于插件的 l.203，覆盖成立。
+
+**两层引号写法**（已实测）：`FZF_*_OPTS` 的值内含 `--preview "…"` 一层引号，是仓库里第一处需要
+两层的生成行。写成 `echo 'export FZF_CTRL_T_OPTS="--preview \"bat …\" …"'` —— 外层 bash 单引号把
+`\"` 原样吐出，zsh 的 `"…"` 再把 `\"` 还原成 `"`，`${(z)…}` 切词后 `--preview` 的参数正是一个整词。
+既守住「`echo` 单引号」的约定，也不必动用 `'\''`。
+
+选定内联界面，不用 `ftb-tmux-popup`。写入前按「与上游默认值有无实质差异」再过滤一遍 ——
+无条件段当初就是这样筛掉 `PYTHON_VENV_NAME` 与 `DIRHISTORY_SIZE` 的。
+
+---
+
+## 5 · 手装二进制的补全落 fpath
+
+**文件**：`debian/command/modern_cli/main.sh` 的 `install_binaries()`
+
+`/usr/local/share/zsh/site-functions/` 是 Debian 默认 fpath 的**第一位**
+（`zsh -f -c 'print -l $fpath'` 实测），专门留给本地安装的软件。omz 用的是**不带 `-C`** 的
+`compinit -i -d "$ZSH_COMPDUMP"`（`oh-my-zsh.sh:127`），每次启动都重扫 fpath，所以文件落盘后
+**下次开 shell 自动生效**：不用删 `.zcompdump`，`.zshrc` 一个字不改。
+
+之所以在安装期写文件、而不是像 omz 插件那样每次启动生成：我们是 setup 脚本，能在安装时介入 ——
+shell 启动零开销，也省掉 `autoload -Uz _xxx; _comps[xxx]=_xxx` 那段（插件必须写那段，是因为它
+加载时 `compinit` 已经跑完了）。代价是工具升级后补全不会自动更新，重跑 setup 即可，而这些补全
+一年也变不了几次。
+
+atuin 的二进制装在 `/usr/local/bin`，补全就走这里（tldr 的补全装在
+`$ZSH_CUSTOM/completions/`，已落地）：
+
+- **atuin** —— tarball 里只有二进制 + README/CHANGELOG/LICENSE，装完自己生成（依赖第 6 节）：
+
+  ```bash
+  atuin gen-completions --shell zsh | sudo tee '/usr/local/share/zsh/site-functions/_atuin' > /dev/null
+  ```
+
+其余工具**不做**（含 apt 装的那批为什么无需处理）见 `CLAUDE.md` 的 debian 否决清单。
+
+---
+
+## 6 · 引入 atuin 接管 `^R` 与 `↑`
+
+**文件**：`debian/command/modern_cli/main.sh`（安装）+ `custom_env.sh` 的 `COMMAND_MODERN_CLI` 块
+（集成）
+
+Debian 13 无 atuin 包（`apt-cache policy atuin` 为空），取 release tarball 装到 `/usr/local/bin`，
+与现有 choose 同套路：
+
+```
+https://github.com/atuinsh/atuin/releases/latest/download/atuin-x86_64-unknown-linux-gnu.tar.gz
+```
+
+（解压后的子目录名落地时确认。）
+
+集成只有一行，追加在 `custom_env.sh` 的 `# Modern CLI tools` 块里：
+
+```zsh
+eval "$(atuin init zsh --disable-ai)"
+```
+
+### 要点
+
+- **接管 `^R` 与 `↑`**：源码 `crates/atuin/src/command/client/init/zsh.rs` 默认绑 `^r`
+  （emacs/viins）、`/`（vicmd）、`^[[A` / `^[OA`（↑）、`k`（vicmd）。因为 eval 在 l.209、晚于
+  l.203 的插件循环，天然覆盖 fzf 的 `^R` 与 omz 的 `up-line-or-beginning-search`。
+  **fzf 插件保留**，仍提供 `^T` 文件、`Alt-C` 目录、`**` 触发补全、`FZF_DEFAULT_COMMAND`。
+- **`--disable-ai` 必加**：官方构建默认把空行开头的 `?` 绑给 Atuin AI（`atuin ai inline`，需要
+  Atuin 账号 + 联网）。
+- **一处非显然的顺序依赖**：`atuin.zsh` 会把 `atuin` **前置**进 `ZSH_AUTOSUGGEST_STRATEGY`，而
+  该变量由 `custom_env.sh` 的无条件段设为 `(history completion)`。无条件段在文件里排在
+  `COMMAND_MODERN_CLI` 块之前，方向正好是「先赋值、后前置」。**反过来就会被覆盖** —— 这条 eval
+  不能挪到无条件段之前。
+  > ⚠️ 上游 [zsh-autosuggestions#797](https://github.com/zsh-users/zsh-autosuggestions/issues/797)
+  > 「Conflict with atuin and completion strategies」未关闭。落地时先验证两者共存是否正常，
+  > 必要时把 `completion` 从策略数组里去掉。
+- **默认纯本地**：不 `atuin register` 就不同步。写 `~/.config/atuin/config.toml`：
+
+  ```toml
+  update_check = false
+  ```
+
+  （源码里默认值是 `cfg!(feature = "check-update")`，官方构建为 true，会在启动后台联网查版本。）
+  落地时决定是整文件 `>` 还是仅在缺失时创建 —— 该文件用户可能自己改过。
+- **`enter_accept` 默认 false**（已核对 `settings.rs:1434`）：TUI 里回车只回填命令行、不直接执行。
+  保持默认。
+- 装完跑 `atuin import auto || true`，从既有 `~/.zsh_history` 导入；全新环境里没历史也无害。
+- **已知短板**：atuin 不接管 `~/.zsh_history`，它另存 SQLite
+  （`~/.local/share/atuin/history.db`）；dev-container 每次重建库为空（除非挂卷或开 sync）。
+  每条命令有 preexec / precmd 两次子进程开销。
+
+---
+
+## 7 · CLAUDE.md 同步
+
+不是独立工作，是上面几节落地后必须一起改的文档债，列出来免得漏：
+
+- **随第 1、2 节**：删掉「omz plugin ordering」里
+  「The debian tree violates 1–3 whenever `--command-modern-cli` is on」那句现状陈述，连同它指向
+  本文 §1、§2 的那半句。
+- **随第 2 节**：在 `00-setup_env.zsh` 一节补一句 —— debian 的「无条件段」有一条 `# z` 是反向
+  gate 的，`cmp` 不变式仍成立（`COMMAND_MODERN_CLI` 默认 0）。
+- **随第 3 节**：更新「Only `PYTHON_AUTO_VRUN` is in the first row today」及其后指向本文 §3 的
+  eza 那句。
+- **随第 4 节**：新记两条 —— zstyle 按具体度决胜、覆盖 omz 的 `menu select` 必须同为五级 pattern；
+  `FZF_*_OPTS` 那种两层引号的生成写法（`echo '… "… \"…\" …"'`）。
+
+---
+
+## 验证
+
+### 离线渲染
+
+方法见 `CLAUDE.md` 的「Linting / running」—— 拿一个一次性 `HOME` + stub `git`，不装任何东西：
+
+```bash
+APP_GIT=1 COMMAND_MODERN_CLI=1 CODE_PYTHON=1 HOME=$T bash debian/command/omz_custom/main.sh
+
+grep '^plugins=' "$T/.zshrc"
+# setup-env 首位、fzf-tab 在 fzf 前、二者都在 zsh-autosuggestions 前、
+# zsh-syntax-highlighting 末位、无 z
+
+cat "$T/.oh-my-zsh/custom/plugins/setup-env/setup-env.plugin.zsh"   # eza zstyle + PYTHON_AUTO_VRUN
+zsh -n "$T/.oh-my-zsh/custom/"{00-setup_env.zsh,01-first_run.zsh}
+zsh -n "$T/.oh-my-zsh/custom/plugins/setup-env/setup-env.plugin.zsh"
+```
+
+全 flag 关闭时，debian 与 macos 生成的 `00-setup_env.zsh` 应 `cmp` 相等，且
+`plugins/setup-env/` 与 `01-first_run.zsh` 都不该生成。
+
+### 实机
+
+```zsh
+bindkey '^R'                # → atuin-search
+bindkey '^[[A'              # → atuin-up-search
+bindkey '^T'                # → fzf-file-widget（fzf 仍在）
+echo $FZF_DEFAULT_COMMAND   # → fd --type f --hidden --follow --exclude .git
+ls -l ~/.local/bin/{fd,bat} # → fdfind / batcat
+```
+
+- 启动无 stderr（重点看 uv / rust / docker 的异步补全生成）。
+- `<TAB>` 走 fzf-tab，有 `[...]` 分组标题与文件配色，`<` `>` 能切组。
+- `cd <TAB>` 出 eza 目录预览；`vim **<TAB>` 走 fzf —— 证明回退链方向正确，且没有套娃出两层 fzf。
+- `^T` 有 bat 预览，且在带 `.gitignore` 的仓库里不列 `node_modules`。
+- `ll` 有表头、git 状态列、图标、相对时间；目录排在前。
+- 空命令行回车：git 仓库出 `git status -u .`，其他目录出 `eza -lah --git --icons`。
+- `fd <TAB>` / `bat <TAB>` / `atuin <TAB>` 均有补全。
+- `atuin stats` 有数据（跑过几条命令后）；空命令行敲 `?` 不触发 AI，就是一个普通字符。
+- `^R` 打开 atuin TUI；tmux 里应为 popup 形式（tmux ≥ 3.2，Debian 13 是 3.5a）。
+- 未开 `--command-modern-cli` 时：`z` 仍在数组里，无 fzf-tab / atuin 相关报错。

--- a/debian/todo.md
+++ b/debian/todo.md
@@ -14,9 +14,11 @@
 - [ ] 5 atuin 的 zsh 补全落 fpath
 - [ ] 6 引入 atuin 接管 `^R` 与 `↑`
 - [ ] 7 CLAUDE.md 同步（随 1–4 落地）
+- [ ] 8 yazi 的推荐配置、插件与 One Dark flavor
 
 1–6 里 1–4 只动 `command/omz_custom/`，5–6 只动 `command/modern_cli/main.sh`，互不冲突，且全部
-gate 在 `--command-modern-cli`，默认安装路径不受影响。7 是随 1–4 一起改的文档债。
+gate 在 `--command-modern-cli`，默认安装路径不受影响。7 是随 1–4 一起改的文档债。8 独立收拢
+`command/modern_cli/yazi/`，只额外改它在 `modern_cli/main.sh` 的调用路径和落地后的 `CLAUDE.md` 说明。
 
 ### Modern CLI 工具配置
 
@@ -38,6 +40,7 @@ gate 在 `--command-modern-cli`，默认安装路径不受影响。7 是随 1–
 - [x] `fd`
 - [x] `micro`
 - [x] `tldr`
+- [ ] `yazi`
 
 ---
 
@@ -215,7 +218,7 @@ shell 启动零开销，也省掉 `autoload -Uz _xxx; _comps[xxx]=_xxx` 那段�
 加载时 `compinit` 已经跑完了）。代价是工具升级后补全不会自动更新，重跑 setup 即可，而这些补全
 一年也变不了几次。
 
-atuin 的二进制装在 `/usr/local/bin`，补全就走这里（tldr 的补全装在
+atuin 的二进制装在 `/usr/local/bin`，补全就走这里（yazi / tldr 那两半装在 `$HOME`，补全走
 `$ZSH_CUSTOM/completions/`，已落地）：
 
 - **atuin** —— tarball 里只有二进制 + README/CHANGELOG/LICENSE，装完自己生成（依赖第 6 节）：
@@ -240,7 +243,7 @@ Debian 13 无 atuin 包（`apt-cache policy atuin` 为空），取 release tarba
 https://github.com/atuinsh/atuin/releases/latest/download/atuin-x86_64-unknown-linux-gnu.tar.gz
 ```
 
-（解压后的子目录名落地时确认。）
+（解压后的子目录名落地时确认，参照 `debian/command/modern_cli/yazi.sh` 的写法。）
 
 集成只有一行，追加在 `custom_env.sh` 的 `# Modern CLI tools` 块里：
 
@@ -296,6 +299,231 @@ eval "$(atuin init zsh --disable-ai)"
 
 ---
 
+## 8 · yazi 的推荐配置、插件与 One Dark flavor
+
+**文件**：把 `debian/command/modern_cli/yazi.sh` 收成 `debian/command/modern_cli/yazi/main.sh`，同目录新增
+`yazi.toml`、`keymap.toml`、`theme.toml`、`init.lua`、`package.toml`；同步
+`debian/command/modern_cli/main.sh` 的调用路径和 `CLAUDE.md` 里所有 `modern_cli/yazi.sh` 现状描述。
+
+**现状** 只从 `releases/latest` zip 安装 `yazi` / `ya` 与 `_yazi` / `_ya`，再安装 MIME 检测所需的
+`file`；没有托管任何 yazi 配置、插件或 flavor。`00-setup_env.zsh` 已有的 `y()` cwd-following 包装保持
+原样，它是 shell 集成，不属于这次配置迁移。
+
+### 先锁住稳定版兼容边界
+
+截至 2026-08-10，`releases/latest` 是
+[`v26.5.6`](https://github.com/sxyazi/yazi/releases/tag/v26.5.6)（2026-05-05 18:30:21 UTC，tag
+`aa526434f00bb44e2e902d9a4ac5f810da1018b9`）。官方
+[`yazi-rs/plugins`](https://github.com/yazi-rs/plugins/tree/0be29a913ad61c6d119abfaaf253e96e6af5db67)
+没有 tag / release，当前 HEAD `0be29a9` 的提交标题就是 `support nightly fetcher API`，根 README 也只笼统
+保证多数插件与 yazi HEAD 同步。**不能**让稳定版 core 配插件 HEAD：插件可选的 `@since` 只声明最低
+版本，不是上限或配对矩阵；未发布的
+[`f42a0df`](https://github.com/sxyazi/yazi/commit/f42a0df4df829b3c774e8f6dd03e10353269a23b)
+已经把 fetcher 从 stable 的 bool / bool-array 返回改成 coroutine 逐文件 yield，正是 stable core + plugins
+HEAD 会撞上的 breaking。以稳定版发布前 plugins 仓库最后一个 revision
+[`ac82af3`](https://github.com/yazi-rs/plugins/tree/ac82af3e10f9a32cecd9f87ac64b3f9de7c7aea7)
+作为起始验证点；它只是 release-date snapshot，不是官方配对，实际落地后仍逐个跑 smoke test。
+
+`package.toml` 同时是 manifest 和 lock：每项有 `use`、Git `rev` 与部署内容 `hash`，应随仓库提交，
+使新环境能用 `ya pkg install` 恢复（维护者也明确这是
+[设计目标](https://github.com/sxyazi/yazi/issues/3758#issuecomment-4053209725)）。用 `ya pkg` 在临时
+`YAZI_CONFIG_HOME` 生成它，不凭空手算 hash；提交前把验证过的 revision 写成 `rev = "=<commit>"`。
+普通 `rev` 已能复现 install，但显式 upgrade 会推进；这里的 `=` 是有意 hard pin，防止用户全局
+`ya pkg upgrade` 把 v26.5.6 配套插件推到 nightly。
+
+安装机只运行 `ya pkg install`：`ya pkg add` 对 manifest 里已有的依赖直接报 `already exists`，本身不是
+可重复部署命令；也不自动运行 `upgrade`，不用会丢弃用户本地插件修改的 `install --discard`。`install`
+对同一个干净 lock **内容收敛但不是无副作用 no-op**：每次仍会 fetch、checkout、重新部署、重算 hash，并
+重写 `package.toml`。该文件会被强类型重新序列化，不能放需要保留的注释、自定义字段或手调排版。
+
+维护升级时先在临时副本去掉目标项 `rev` 的前导 `=`，再运行 `ya pkg upgrade`、审查 rev / hash / API diff，
+验证后重新加 `=` 并与 core / 配置迁移一起提交。`install` 只遍历 manifest，**不会 prune**：删除依赖时要在
+旧条目仍存在时先执行 `ya pkg delete <id>`，或在部署新 manifest 前显式删除该 package-owned 目录，不能只
+删静态清单条目。官方语义见 [`ya pkg`](https://yazi-rs.github.io/docs/cli/#pm)；稳定版实现见
+[`install.rs`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-cli/src/package/install.rs#L7-L24)、
+[`upgrade.rs`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-cli/src/package/upgrade.rs#L5-L8)、
+[`package.rs`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-cli/src/package/package.rs#L40-L55)、
+[`hash.rs`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-cli/src/package/hash.rs#L8-L55) 与
+[`deploy.rs`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-cli/src/package/deploy.rs#L11-L39)。
+`hash` 是非密码学 XxHash3-128 本地修改指纹，不是版本号，也不是供应链完整性校验。
+
+这仍不是完整版本锁定：现有二进制渠道有意跟随 `releases/latest`，而 `package.toml` 只锁插件与 flavor。
+保留这个仓库既定下载 URL，但 `main.sh` 必须在临时目录下载完成后、覆盖任何现有文件之前读取
+`"$dir/yazi" --version`，只接受静态 lock 已验证的 core（首个映射是 v26.5.6 → plugins `ac82af3` +
+onedark `3735edb`）；未知版本 fail closed，打印“先原子更新 core 版本门、package rev / hash、配置 API 与
+smoke test”，不能安装二进制、补全、配置或 packages，也不能悄悄切回 HEAD。这样 future `latest` 会响亮
+要求维护，而不是留下新 core + 旧 lock 的半升级环境。
+
+### 目标落点
+
+```text
+debian/command/modern_cli/yazi/
+├── main.sh
+├── init.lua
+├── keymap.toml
+├── package.toml
+├── theme.toml
+└── yazi.toml
+```
+
+`main.sh` 在现有二进制与补全安装之后，用 `install -Dm 644` 部署五个静态 artifact 到
+`~/.config/yazi/`，再运行 `ya pkg install`。三个配置 TOML（不含 package manifest）都只写对上游
+preset 的最小 overlay；数组不能靠
+“同名自动合并”的猜测，键位、open rules、fetchers / previewers 一律用官方 `prepend_*` / `append_*`
+入口，避免覆盖默认数组（稳定版依据：[`keymap`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-config/src/keymap/rules.rs#L11-L52)、
+[`open`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-config/src/open/open.rs#L13-L60)、
+[`plugin`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-config/src/plugin/plugin.rs#L11-L68)）。
+`init.lua` 没有 TOML 的 merge 语义，每进程启动同步执行一次，托管即整文件所有权；这里只初始化下面的
+插件，不复制上游 Lua preset（见 [`standard.rs`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-plugin/src/standard.rs#L11-L72)）。
+
+这里沿用仓库对 bat / micro / lazygit 的既定所有权：五个文件是 setup-env 的版本化 artifact，重跑时
+**有意覆盖**，让配置迁移能落到已有机器；不采用“仅在缺失时创建”，否则第一次安装后的内容永久陈旧。
+边界在 package 目录：`plugins/*.yazi` / `flavors/*.yazi` 由 `ya pkg` 管，若 hash 发现用户改过就响亮中止；
+禁止 `--discard` 正是为了不越过这条边界。
+
+#### `yazi.toml`
+
+只设三项确实偏离 v26.5.6 默认值、且适合开发目录的基础行为：自然排序、显示 size linemode、默认显示
+点文件；`sort_dir_first = true` 已是默认值，不重述。
+
+```toml
+[mgr]
+sort_by = "natural"
+linemode = "size"
+show_hidden = true
+```
+
+再注册两类官方插件，必须使用与稳定 revision 同期 README 的字段。`git.yazi` 的状态标记通过
+`Linemode:children_add()` 追加，不会吃掉上面的 size linemode；v26.5.6 已高于 README 注释的
+v26.1.22 分界，所以两条都不带旧 `id = "git"`：
+
+```toml
+[[plugin.prepend_fetchers]]
+url = "*"
+run = "git"
+group = "git"
+
+[[plugin.prepend_fetchers]]
+url = "*/"
+run = "git"
+group = "git"
+
+[[plugin.prepend_previewers]]
+url = "*.md"
+run = 'piper -- CLICOLOR_FORCE=1 glow -w=$w -s=dark "$1"'
+```
+
+Markdown 预览直接复用 `--command-modern-cli` 已安装的 `glow`，不新增依赖。这里的 `-s=dark` 是
+Glow 内置主题，与下面的 Yazi One Dark flavor 无关；`CLICOLOR_FORCE=1` 能保留非 TTY 的 ANSI 色彩，但
+Glow 2.x 会把其中的 RGB 细节量化为 256 色，验收只要求可读、不要求 TrueColor 一致。不要再写
+editor / opener：Yazi 默认文本 opener 已读取 `EDITOR=micro`（VS Code 分支也经同一个环境变量生效）。也不配置
+fd、rg、fzf、zoxide：core 自己识别 `fd` / `fdfind`，默认 keymap 已有 `z` → fzf、`Z` → zoxide。
+
+#### `keymap.toml` 与 `init.lua`
+
+只占两个当前默认行为能被严格增强的键：`l` 对目录 enter、对文件 open；`T` 在窄 SSH / tmux 界面隐藏或
+恢复 preview pane。两项都用 prepend，不复制整份默认 keymap。
+
+```toml
+[[mgr.prepend_keymap]]
+on = "l"
+run = "plugin smart-enter"
+desc = "Enter the child directory, or open the file"
+
+[[mgr.prepend_keymap]]
+on = "T"
+run = "plugin toggle-pane min-preview"
+desc = "Show or hide the preview pane"
+```
+
+`smart-enter` 保持默认 `open_multi = false`，避免一次误开全部 selected 文件。`init.lua` 只需：
+
+```lua
+require("git"):setup {
+    order = 1500,
+}
+```
+
+`git.yazi` 的默认 status signs 含 Nerd Font 私用区字符：复用第 3 节 `icons` 的字体前提；若实机不是
+Nerd Font v3，就在 `require("git"):setup()` 之前按该 revision README 覆盖为 ASCII signs，不能留下方框。
+
+目标官方插件共四个，全部预定 pin 到同一个稳定版同期 revision，并以本项 smoke test 作为落地门槛：
+
+| package | 作用 | 上游依据 |
+| --- | --- | --- |
+| `yazi-rs/plugins:git` | 当前列表显示 Git 状态；`git` 已是整个 setup 的硬前置 | [`git.yazi`](https://github.com/yazi-rs/plugins/tree/ac82af3e10f9a32cecd9f87ac64b3f9de7c7aea7/git.yazi) |
+| `yazi-rs/plugins:smart-enter` | 一个 `l` 同时覆盖 enter / open | [`smart-enter.yazi`](https://github.com/yazi-rs/plugins/tree/ac82af3e10f9a32cecd9f87ac64b3f9de7c7aea7/smart-enter.yazi) |
+| `yazi-rs/plugins:piper` | 把现有 glow 用作 Markdown previewer | [`piper.yazi`](https://github.com/yazi-rs/plugins/tree/ac82af3e10f9a32cecd9f87ac64b3f9de7c7aea7/piper.yazi) |
+| `yazi-rs/plugins:toggle-pane` | 窄终端隐藏 / 恢复 preview pane | [`toggle-pane.yazi`](https://github.com/yazi-rs/plugins/tree/ac82af3e10f9a32cecd9f87ac64b3f9de7c7aea7/toggle-pane.yazi) |
+
+#### `theme.toml`
+
+官方 flavors 仓库在
+[`be0b21d`](https://github.com/yazi-rs/flavors/tree/be0b21d0873092a63946cc2678dd700aac945902)
+只有 Dracula 与四个 Catppuccin，**没有** One Dark，不能写不存在的 `yazi-rs/flavors:onedark`。为了与
+micro `one-dark`、bat / delta `TwoDark` 和 VS Code One Dark Pro 保持一致，采用第三方
+[`damjee/onedark`](https://github.com/damjee/onedark.yazi/tree/3735edba144b17e3eb08fde9ffdaaf99f8ea9542)：
+它是 MIT、只有静态 `flavor.toml` / `tmtheme.xml`，`3735edb` 已使用当前 `[mgr]` / `[tabs]` / `[cmp]` /
+`[spot]` schema，并已在 yazi v26.5.6 下通过 `ya pkg add` + `yazi --debug` 解析。pin 这个 revision 与
+生成的 hash，`theme.toml` 只写：
+
+```toml
+[flavor]
+dark = "onedark"
+light = "onedark"
+```
+
+这个 flavor 只有暗色方案；同时设置 `dark` / `light` 是有意让 Yazi 在两种终端检测结果下都保持仓库统一的
+One Dark，不是在声称它支持浅色。只写 `dark` 会让 light 模式退回内置浅色 preset，与 micro / bat /
+delta / VS Code 的固定暗色配置不一致。
+
+启用 flavor 后，v26.5.6 的最终
+[`Theme::reshape()`](https://github.com/sxyazi/yazi/blob/aa526434f00bb44e2e902d9a4ac5f810da1018b9/yazi-config/src/theme/theme.rs#L232-L246)
+会把 `mgr.syntect_theme` 强制指向该 flavor 自带的 `tmtheme.xml`，这是“preset → flavor → 用户
+theme overlay”顺序的明确例外；此处正好需要 One Dark 的代码预览主题，所以不再尝试从用户 `theme.toml`
+覆盖它。
+
+这是明确的第三方信任边界：每次升级都重新审计完整静态 diff；若该 flavor 停更或引入可执行 Lua，就退回
+Yazi 默认主题，而不是静默换成不一致的 Dracula / Catppuccin。不要选仍使用旧 `[manager]` schema 的
+`AugustDG/onedark`，也不要复活历史 [`BennyOe/onedark`](https://github.com/BennyOe/onedark.yazi/tree/668d71d967857392012684c7dd111605cfa36d1a)：
+它已因 outdated / unmaintained 被
+[官方目录移除](https://github.com/yazi-rs/flavors/commit/4296a380570399e3c36aec054f37aa48f35cf6b1)，
+且还是 v0.2.4–v0.3.3 时代的旧 schema。
+
+### 明确不做
+
+- **不装整仓库插件**。`full-border` 浪费窄终端宽度；`smart-filter` / `smart-paste` 收益不足以再占默认键；
+  `vcs-files` 与 lazygit / 普通 Git 工作流重叠；`diff` 同样重叠且 headless 环境没有它需要的剪贴板 helper；
+  `mount`、`mactag`、clipboard 类功能依赖桌面 / 平台服务；`zoom` 等媒体插件会引入 ImageMagick。
+- **不默认装 `mime-ext`**。它用扩展名准确率换速度，而现有 `file(1)` 路径没有已知瓶颈；只有实测远程
+  大目录 MIME 成为热点后再考虑。
+- **不硬编码图片 adapter，也不伪造 `TERM` / `TERM_PROGRAM`**。Yazi 按真实终端 / display 能力选择；
+  无原生协议时本机 `yazi --debug` 会落到 Chafa，但最小 Debian 13 上安装 `chafa` 即使
+  `--no-install-recommends` 仍新增 45 个包。当前取舍是允许该路径没有图片预览，不为它拉入 Cairo、Pango、
+  字体与图像编解码栈；通过真实 SSH / tmux 会话跑 `yazi --debug` 验证降级即可。
+- **不复制默认 preset**。尤其不重写完整 keymap、open rules、spotters、preloaders、fetchers 或
+  previewers；这些正是 core 升级最容易漂移的数组。
+
+### 本项验证
+
+1. `shellcheck debian/command/modern_cli/yazi/main.sh`；五个 artifact 的 mode 都是 0644，目标目录由
+   `install -D` 创建。
+2. 用下载目录里的 stub `yazi --version` 分别返回 v26.5.6 与一个未知 future 版本：前者进入对应 lock，
+   后者在覆盖二进制 / 补全、复制配置、`ya pkg install` 和任何 package 目录写入之前非零退出，并打印原子
+   升级提示。
+3. 一次性 `YAZI_CONFIG_HOME` 下部署文件并运行 `ya pkg install`、`yazi --debug`：无 TOML / Lua / flavor
+   解析错误，四个插件与一个 flavor 的实际 revision / hash 等于 `package.toml`。
+4. 再跑一次 `ya pkg install` 和 setup：允许 fetch / redeploy / manifest 重写，但最终 use / rev / hash、
+   配置内容与已部署包内容收敛，不重复追加、不产生 HEAD 漂移（比内容，不拿 mtime 当幂等标准）。再用一个
+   临时待删除依赖验证显式 `ya pkg delete` / 目录迁移，证明只删 manifest 条目确实不会被 `install` prune。
+5. 实机检查：点文件可见，`file2` 排在 `file10` 前，size 与 Git 状态同时出现；`l` 能 enter / open，
+   `T` 能隐藏 / 恢复 preview；Markdown 由 Glow 内置 `dark` 正常渲染，非 TTY 下允许 ANSI/256 色降级；
+   Yazi UI 与代码预览仍由 flavor 保持 One Dark。
+6. 从目录内用 `y` 启动并退出后仍能带 shell 切换 cwd；无图片协议、无 `chafa`、非 Git 目录和没有
+   Markdown 文件时都安静退化，不影响普通浏览 / 打开文件。
+
+---
+
 ## 验证
 
 ### 离线渲染
@@ -325,6 +553,8 @@ bindkey '^[[A'              # → atuin-up-search
 bindkey '^T'                # → fzf-file-widget（fzf 仍在）
 echo $FZF_DEFAULT_COMMAND   # → fd --type f --hidden --follow --exclude .git
 ls -l ~/.local/bin/{fd,bat} # → fdfind / batcat
+yazi --version              # → 本次 package.toml 验证过的稳定版
+ya pkg list                 # → 4 plugins + onedark flavor，revision 均被锁定
 ```
 
 - 启动无 stderr（重点看 uv / rust / docker 的异步补全生成）。
@@ -333,7 +563,10 @@ ls -l ~/.local/bin/{fd,bat} # → fdfind / batcat
 - `^T` 有 bat 预览，且在带 `.gitignore` 的仓库里不列 `node_modules`。
 - `ll` 有表头、git 状态列、图标、相对时间；目录排在前。
 - 空命令行回车：git 仓库出 `git status -u .`，其他目录出 `eza -lah --git --icons`。
-- `fd <TAB>` / `bat <TAB>` / `atuin <TAB>` 均有补全。
+- `fd <TAB>` / `bat <TAB>` / `atuin <TAB>` 均有补全（`yazi <TAB>` / `ya <TAB>` 由
+  `command/modern_cli/yazi/main.sh` 装的 `_yazi` / `_ya` 提供）。
+- yazi 同时显示 size 与 Git 状态，`l` / `T` 和 glow Markdown 预览生效；无 `chafa` 时普通文件浏览、
+  One Dark flavor 与 `y()` cwd-following 仍正常，启动日志没有插件 API 错误。
 - `atuin stats` 有数据（跑过几条命令后）；空命令行敲 `?` 不触发 AI，就是一个普通字符。
 - `^R` 打开 atuin TUI；tmux 里应为 popup 形式（tmux ≥ 3.2，Debian 13 是 3.5a）。
 - 未开 `--command-modern-cli` 时：`z` 仍在数组里，无 fzf-tab / atuin 相关报错。


### PR DESCRIPTION
## 概要

- 将旧 command utils 与 Micro 迁入统一的 Modern CLI dispatcher
- 添加独立的 bat、fdfind、tldr 和 yazi 安装组件
- 更新 Oh My Zsh 集成、运行期配置、文档与后续工作清单

## 验证

- `bash -n`：全部 shell 脚本通过
- `shellcheck`：本次变更脚本通过
- Micro `settings.json`：通过 `jq empty`
- dispatcher 参数解析与生成的 zsh 配置检查通过
- 拆分后 tree 与原始功能提交完全一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)